### PR TITLE
Serve safe ads over https, regardless of adserver type

### DIFF
--- a/lib/max/Delivery/adSelect.php
+++ b/lib/max/Delivery/adSelect.php
@@ -984,8 +984,7 @@ function _adSelectCheckCriteria($aAd, $aContext, $source, $richMedia)
         return false;
     }
 
-    if ($GLOBALS['_MAX']['SSL_REQUEST'] && $aAd['type'] == 'html' &&
-        (($aAd['adserver'] != 'max' && $aAd['adserver'] != '3rdPartyServers:ox3rdPartyServers:max') || $aAd['html_ssl_unsafe'])) {
+    if ($GLOBALS['_MAX']['SSL_REQUEST'] && $aAd['type'] == 'html' && $aAd['html_ssl_unsafe']) {
         // HTML Banners that contain 'http:' on SSL
         OX_Delivery_logMessage('"http:" on SSL found for html bannerid '.$aAd['ad_id'], 7);
         return false;

--- a/www/delivery/ac.php
+++ b/www/delivery/ac.php
@@ -159,7 +159,7 @@ $GLOBALS['_MAX']['MAX_COOKIELESS_PREFIX'] = '__';
 $GLOBALS['_MAX']['thread_id'] = uniqid();
 $GLOBALS['_MAX']['SSL_REQUEST'] = false;
 if (
-(!empty($_SERVER['SERVER_PORT']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
+(!empty($_SERVER['SERVER_PORT']) && !empty($GLOBALS['_MAX']['CONF']['openads']['sslPort']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
 (!empty($_SERVER['HTTPS']) && ((strtolower($_SERVER['HTTPS']) == 'on') || ($_SERVER['HTTPS'] == 1))) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && (strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https')) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_SSL']) && (strtolower($_SERVER['HTTP_X_FORWARDED_SSL']) == 'on')) ||
@@ -257,9 +257,9 @@ setupDeliveryConfigVariables();
 $conf = $GLOBALS['_MAX']['CONF'];
 $GLOBALS['_OA']['invocationType'] = array_search(basename($_SERVER['SCRIPT_FILENAME']), $conf['file']);
 if (!empty($conf['debug']['production'])) {
-error_reporting(E_ALL ^ E_NOTICE ^ E_WARNING ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_NOTICE | E_WARNING | E_DEPRECATED | E_STRICT));
 } else {
-error_reporting(E_ALL ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_DEPRECATED | E_STRICT));
 }
 
 $file = '/lib/max/Delivery/common.php';
@@ -3096,7 +3096,7 @@ function MAX_limitationsIsZoneForbidden($zoneId, $aCapping)
 $capZone = isset($aCapping['cap_zone']) ? $aCapping['cap_zone'] : null;
 $sessionCapZone = isset($aCapping['session_cap_zone']) ? $aCapping['session_cap_zone'] : null;
 $blockZone = isset($aCapping['block_zone']) ? $aCapping['block_zone'] : null;
-$showCappedNoCookie = (bool)$aCapping['show_capped_no_cookie_zone'];
+$showCappedNoCookie = !empty($aCapping['show_capped_no_cookie_zone']);
 return (_limitationsIsZoneCapped($zoneId, $capZone, $sessionCapZone, $blockZone, $showCappedNoCookie));
 }
 function _limitationsIsAdCapped($adId, $cap, $sessionCap = 0, $block, $showCappedNoCookie)
@@ -3166,7 +3166,7 @@ $random = MAX_getRandomNumber();
 global $cookie_random;  $cookie_random = $random;
 $clickUrl = _adRenderBuildClickUrl($aBanner, $zoneId, $source, $ct0, $logClick, true);
 $urlPrefix = substr(MAX_commonGetDeliveryUrl(), 0, -1);
-$code = str_replace('{clickurl}', $clickUrl, $code);
+$code = str_replace('{clickurl}', $clickUrl, $code); 
 if (strpos($code, '{logurl}') !== false) {
 $logUrl = _adRenderBuildLogURL($aBanner, $zoneId, $source, $loc, $referer, '&');
 $code = str_replace('{logurl}', $logUrl, $code);  }
@@ -4092,8 +4092,7 @@ if (MAX_limitationsIsAdForbidden($aAd)) {
 OX_Delivery_logMessage('MAX_limitationsIsAdForbidden = true for bannerid '.$aAd['ad_id'], 7);
 return false;
 }
-if ($GLOBALS['_MAX']['SSL_REQUEST'] && $aAd['type'] == 'html' &&
-(($aAd['adserver'] != 'max' && $aAd['adserver'] != '3rdPartyServers:ox3rdPartyServers:max') || $aAd['html_ssl_unsafe'])) {
+if ($GLOBALS['_MAX']['SSL_REQUEST'] && $aAd['type'] == 'html' && $aAd['html_ssl_unsafe']) {
 OX_Delivery_logMessage('"http:" on SSL found for html bannerid '.$aAd['ad_id'], 7);
 return false;
 }

--- a/www/delivery/afr.php
+++ b/www/delivery/afr.php
@@ -159,7 +159,7 @@ $GLOBALS['_MAX']['MAX_COOKIELESS_PREFIX'] = '__';
 $GLOBALS['_MAX']['thread_id'] = uniqid();
 $GLOBALS['_MAX']['SSL_REQUEST'] = false;
 if (
-(!empty($_SERVER['SERVER_PORT']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
+(!empty($_SERVER['SERVER_PORT']) && !empty($GLOBALS['_MAX']['CONF']['openads']['sslPort']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
 (!empty($_SERVER['HTTPS']) && ((strtolower($_SERVER['HTTPS']) == 'on') || ($_SERVER['HTTPS'] == 1))) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && (strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https')) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_SSL']) && (strtolower($_SERVER['HTTP_X_FORWARDED_SSL']) == 'on')) ||
@@ -257,9 +257,9 @@ setupDeliveryConfigVariables();
 $conf = $GLOBALS['_MAX']['CONF'];
 $GLOBALS['_OA']['invocationType'] = array_search(basename($_SERVER['SCRIPT_FILENAME']), $conf['file']);
 if (!empty($conf['debug']['production'])) {
-error_reporting(E_ALL ^ E_NOTICE ^ E_WARNING ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_NOTICE | E_WARNING | E_DEPRECATED | E_STRICT));
 } else {
-error_reporting(E_ALL ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_DEPRECATED | E_STRICT));
 }
 
 $file = '/lib/max/Delivery/common.php';
@@ -3096,7 +3096,7 @@ function MAX_limitationsIsZoneForbidden($zoneId, $aCapping)
 $capZone = isset($aCapping['cap_zone']) ? $aCapping['cap_zone'] : null;
 $sessionCapZone = isset($aCapping['session_cap_zone']) ? $aCapping['session_cap_zone'] : null;
 $blockZone = isset($aCapping['block_zone']) ? $aCapping['block_zone'] : null;
-$showCappedNoCookie = (bool)$aCapping['show_capped_no_cookie_zone'];
+$showCappedNoCookie = !empty($aCapping['show_capped_no_cookie_zone']);
 return (_limitationsIsZoneCapped($zoneId, $capZone, $sessionCapZone, $blockZone, $showCappedNoCookie));
 }
 function _limitationsIsAdCapped($adId, $cap, $sessionCap = 0, $block, $showCappedNoCookie)
@@ -3166,7 +3166,7 @@ $random = MAX_getRandomNumber();
 global $cookie_random;  $cookie_random = $random;
 $clickUrl = _adRenderBuildClickUrl($aBanner, $zoneId, $source, $ct0, $logClick, true);
 $urlPrefix = substr(MAX_commonGetDeliveryUrl(), 0, -1);
-$code = str_replace('{clickurl}', $clickUrl, $code);
+$code = str_replace('{clickurl}', $clickUrl, $code); 
 if (strpos($code, '{logurl}') !== false) {
 $logUrl = _adRenderBuildLogURL($aBanner, $zoneId, $source, $loc, $referer, '&');
 $code = str_replace('{logurl}', $logUrl, $code);  }
@@ -4092,8 +4092,7 @@ if (MAX_limitationsIsAdForbidden($aAd)) {
 OX_Delivery_logMessage('MAX_limitationsIsAdForbidden = true for bannerid '.$aAd['ad_id'], 7);
 return false;
 }
-if ($GLOBALS['_MAX']['SSL_REQUEST'] && $aAd['type'] == 'html' &&
-(($aAd['adserver'] != 'max' && $aAd['adserver'] != '3rdPartyServers:ox3rdPartyServers:max') || $aAd['html_ssl_unsafe'])) {
+if ($GLOBALS['_MAX']['SSL_REQUEST'] && $aAd['type'] == 'html' && $aAd['html_ssl_unsafe']) {
 OX_Delivery_logMessage('"http:" on SSL found for html bannerid '.$aAd['ad_id'], 7);
 return false;
 }

--- a/www/delivery/ag.php
+++ b/www/delivery/ag.php
@@ -159,7 +159,7 @@ $GLOBALS['_MAX']['MAX_COOKIELESS_PREFIX'] = '__';
 $GLOBALS['_MAX']['thread_id'] = uniqid();
 $GLOBALS['_MAX']['SSL_REQUEST'] = false;
 if (
-(!empty($_SERVER['SERVER_PORT']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
+(!empty($_SERVER['SERVER_PORT']) && !empty($GLOBALS['_MAX']['CONF']['openads']['sslPort']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
 (!empty($_SERVER['HTTPS']) && ((strtolower($_SERVER['HTTPS']) == 'on') || ($_SERVER['HTTPS'] == 1))) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && (strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https')) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_SSL']) && (strtolower($_SERVER['HTTP_X_FORWARDED_SSL']) == 'on')) ||
@@ -257,9 +257,9 @@ setupDeliveryConfigVariables();
 $conf = $GLOBALS['_MAX']['CONF'];
 $GLOBALS['_OA']['invocationType'] = array_search(basename($_SERVER['SCRIPT_FILENAME']), $conf['file']);
 if (!empty($conf['debug']['production'])) {
-error_reporting(E_ALL ^ E_NOTICE ^ E_WARNING ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_NOTICE | E_WARNING | E_DEPRECATED | E_STRICT));
 } else {
-error_reporting(E_ALL ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_DEPRECATED | E_STRICT));
 }
 
 $file = '/lib/max/Delivery/common.php';

--- a/www/delivery/ai.php
+++ b/www/delivery/ai.php
@@ -159,7 +159,7 @@ $GLOBALS['_MAX']['MAX_COOKIELESS_PREFIX'] = '__';
 $GLOBALS['_MAX']['thread_id'] = uniqid();
 $GLOBALS['_MAX']['SSL_REQUEST'] = false;
 if (
-(!empty($_SERVER['SERVER_PORT']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
+(!empty($_SERVER['SERVER_PORT']) && !empty($GLOBALS['_MAX']['CONF']['openads']['sslPort']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
 (!empty($_SERVER['HTTPS']) && ((strtolower($_SERVER['HTTPS']) == 'on') || ($_SERVER['HTTPS'] == 1))) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && (strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https')) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_SSL']) && (strtolower($_SERVER['HTTP_X_FORWARDED_SSL']) == 'on')) ||
@@ -257,9 +257,9 @@ setupDeliveryConfigVariables();
 $conf = $GLOBALS['_MAX']['CONF'];
 $GLOBALS['_OA']['invocationType'] = array_search(basename($_SERVER['SCRIPT_FILENAME']), $conf['file']);
 if (!empty($conf['debug']['production'])) {
-error_reporting(E_ALL ^ E_NOTICE ^ E_WARNING ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_NOTICE | E_WARNING | E_DEPRECATED | E_STRICT));
 } else {
-error_reporting(E_ALL ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_DEPRECATED | E_STRICT));
 }
 
 $file = '/lib/max/Delivery/common.php';

--- a/www/delivery/ajs.php
+++ b/www/delivery/ajs.php
@@ -159,7 +159,7 @@ $GLOBALS['_MAX']['MAX_COOKIELESS_PREFIX'] = '__';
 $GLOBALS['_MAX']['thread_id'] = uniqid();
 $GLOBALS['_MAX']['SSL_REQUEST'] = false;
 if (
-(!empty($_SERVER['SERVER_PORT']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
+(!empty($_SERVER['SERVER_PORT']) && !empty($GLOBALS['_MAX']['CONF']['openads']['sslPort']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
 (!empty($_SERVER['HTTPS']) && ((strtolower($_SERVER['HTTPS']) == 'on') || ($_SERVER['HTTPS'] == 1))) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && (strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https')) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_SSL']) && (strtolower($_SERVER['HTTP_X_FORWARDED_SSL']) == 'on')) ||
@@ -257,9 +257,9 @@ setupDeliveryConfigVariables();
 $conf = $GLOBALS['_MAX']['CONF'];
 $GLOBALS['_OA']['invocationType'] = array_search(basename($_SERVER['SCRIPT_FILENAME']), $conf['file']);
 if (!empty($conf['debug']['production'])) {
-error_reporting(E_ALL ^ E_NOTICE ^ E_WARNING ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_NOTICE | E_WARNING | E_DEPRECATED | E_STRICT));
 } else {
-error_reporting(E_ALL ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_DEPRECATED | E_STRICT));
 }
 
 $file = '/lib/max/Delivery/common.php';
@@ -3096,7 +3096,7 @@ function MAX_limitationsIsZoneForbidden($zoneId, $aCapping)
 $capZone = isset($aCapping['cap_zone']) ? $aCapping['cap_zone'] : null;
 $sessionCapZone = isset($aCapping['session_cap_zone']) ? $aCapping['session_cap_zone'] : null;
 $blockZone = isset($aCapping['block_zone']) ? $aCapping['block_zone'] : null;
-$showCappedNoCookie = (bool)$aCapping['show_capped_no_cookie_zone'];
+$showCappedNoCookie = !empty($aCapping['show_capped_no_cookie_zone']);
 return (_limitationsIsZoneCapped($zoneId, $capZone, $sessionCapZone, $blockZone, $showCappedNoCookie));
 }
 function _limitationsIsAdCapped($adId, $cap, $sessionCap = 0, $block, $showCappedNoCookie)
@@ -3166,7 +3166,7 @@ $random = MAX_getRandomNumber();
 global $cookie_random;  $cookie_random = $random;
 $clickUrl = _adRenderBuildClickUrl($aBanner, $zoneId, $source, $ct0, $logClick, true);
 $urlPrefix = substr(MAX_commonGetDeliveryUrl(), 0, -1);
-$code = str_replace('{clickurl}', $clickUrl, $code);
+$code = str_replace('{clickurl}', $clickUrl, $code); 
 if (strpos($code, '{logurl}') !== false) {
 $logUrl = _adRenderBuildLogURL($aBanner, $zoneId, $source, $loc, $referer, '&');
 $code = str_replace('{logurl}', $logUrl, $code);  }
@@ -4092,8 +4092,7 @@ if (MAX_limitationsIsAdForbidden($aAd)) {
 OX_Delivery_logMessage('MAX_limitationsIsAdForbidden = true for bannerid '.$aAd['ad_id'], 7);
 return false;
 }
-if ($GLOBALS['_MAX']['SSL_REQUEST'] && $aAd['type'] == 'html' &&
-(($aAd['adserver'] != 'max' && $aAd['adserver'] != '3rdPartyServers:ox3rdPartyServers:max') || $aAd['html_ssl_unsafe'])) {
+if ($GLOBALS['_MAX']['SSL_REQUEST'] && $aAd['type'] == 'html' && $aAd['html_ssl_unsafe']) {
 OX_Delivery_logMessage('"http:" on SSL found for html bannerid '.$aAd['ad_id'], 7);
 return false;
 }

--- a/www/delivery/al.php
+++ b/www/delivery/al.php
@@ -159,7 +159,7 @@ $GLOBALS['_MAX']['MAX_COOKIELESS_PREFIX'] = '__';
 $GLOBALS['_MAX']['thread_id'] = uniqid();
 $GLOBALS['_MAX']['SSL_REQUEST'] = false;
 if (
-(!empty($_SERVER['SERVER_PORT']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
+(!empty($_SERVER['SERVER_PORT']) && !empty($GLOBALS['_MAX']['CONF']['openads']['sslPort']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
 (!empty($_SERVER['HTTPS']) && ((strtolower($_SERVER['HTTPS']) == 'on') || ($_SERVER['HTTPS'] == 1))) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && (strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https')) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_SSL']) && (strtolower($_SERVER['HTTP_X_FORWARDED_SSL']) == 'on')) ||
@@ -257,9 +257,9 @@ setupDeliveryConfigVariables();
 $conf = $GLOBALS['_MAX']['CONF'];
 $GLOBALS['_OA']['invocationType'] = array_search(basename($_SERVER['SCRIPT_FILENAME']), $conf['file']);
 if (!empty($conf['debug']['production'])) {
-error_reporting(E_ALL ^ E_NOTICE ^ E_WARNING ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_NOTICE | E_WARNING | E_DEPRECATED | E_STRICT));
 } else {
-error_reporting(E_ALL ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_DEPRECATED | E_STRICT));
 }
 
 $file = '/lib/max/Delivery/common.php';
@@ -3096,7 +3096,7 @@ function MAX_limitationsIsZoneForbidden($zoneId, $aCapping)
 $capZone = isset($aCapping['cap_zone']) ? $aCapping['cap_zone'] : null;
 $sessionCapZone = isset($aCapping['session_cap_zone']) ? $aCapping['session_cap_zone'] : null;
 $blockZone = isset($aCapping['block_zone']) ? $aCapping['block_zone'] : null;
-$showCappedNoCookie = (bool)$aCapping['show_capped_no_cookie_zone'];
+$showCappedNoCookie = !empty($aCapping['show_capped_no_cookie_zone']);
 return (_limitationsIsZoneCapped($zoneId, $capZone, $sessionCapZone, $blockZone, $showCappedNoCookie));
 }
 function _limitationsIsAdCapped($adId, $cap, $sessionCap = 0, $block, $showCappedNoCookie)
@@ -3166,7 +3166,7 @@ $random = MAX_getRandomNumber();
 global $cookie_random;  $cookie_random = $random;
 $clickUrl = _adRenderBuildClickUrl($aBanner, $zoneId, $source, $ct0, $logClick, true);
 $urlPrefix = substr(MAX_commonGetDeliveryUrl(), 0, -1);
-$code = str_replace('{clickurl}', $clickUrl, $code);
+$code = str_replace('{clickurl}', $clickUrl, $code); 
 if (strpos($code, '{logurl}') !== false) {
 $logUrl = _adRenderBuildLogURL($aBanner, $zoneId, $source, $loc, $referer, '&');
 $code = str_replace('{logurl}', $logUrl, $code);  }
@@ -4092,8 +4092,7 @@ if (MAX_limitationsIsAdForbidden($aAd)) {
 OX_Delivery_logMessage('MAX_limitationsIsAdForbidden = true for bannerid '.$aAd['ad_id'], 7);
 return false;
 }
-if ($GLOBALS['_MAX']['SSL_REQUEST'] && $aAd['type'] == 'html' &&
-(($aAd['adserver'] != 'max' && $aAd['adserver'] != '3rdPartyServers:ox3rdPartyServers:max') || $aAd['html_ssl_unsafe'])) {
+if ($GLOBALS['_MAX']['SSL_REQUEST'] && $aAd['type'] == 'html' && $aAd['html_ssl_unsafe']) {
 OX_Delivery_logMessage('"http:" on SSL found for html bannerid '.$aAd['ad_id'], 7);
 return false;
 }

--- a/www/delivery/alocal.php
+++ b/www/delivery/alocal.php
@@ -159,7 +159,7 @@ $GLOBALS['_MAX']['MAX_COOKIELESS_PREFIX'] = '__';
 $GLOBALS['_MAX']['thread_id'] = uniqid();
 $GLOBALS['_MAX']['SSL_REQUEST'] = false;
 if (
-(!empty($_SERVER['SERVER_PORT']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
+(!empty($_SERVER['SERVER_PORT']) && !empty($GLOBALS['_MAX']['CONF']['openads']['sslPort']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
 (!empty($_SERVER['HTTPS']) && ((strtolower($_SERVER['HTTPS']) == 'on') || ($_SERVER['HTTPS'] == 1))) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && (strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https')) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_SSL']) && (strtolower($_SERVER['HTTP_X_FORWARDED_SSL']) == 'on')) ||
@@ -257,9 +257,9 @@ setupDeliveryConfigVariables();
 $conf = $GLOBALS['_MAX']['CONF'];
 $GLOBALS['_OA']['invocationType'] = array_search(basename($_SERVER['SCRIPT_FILENAME']), $conf['file']);
 if (!empty($conf['debug']['production'])) {
-error_reporting(E_ALL ^ E_NOTICE ^ E_WARNING ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_NOTICE | E_WARNING | E_DEPRECATED | E_STRICT));
 } else {
-error_reporting(E_ALL ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_DEPRECATED | E_STRICT));
 }
 
 $file = '/lib/max/Delivery/common.php';
@@ -3096,7 +3096,7 @@ function MAX_limitationsIsZoneForbidden($zoneId, $aCapping)
 $capZone = isset($aCapping['cap_zone']) ? $aCapping['cap_zone'] : null;
 $sessionCapZone = isset($aCapping['session_cap_zone']) ? $aCapping['session_cap_zone'] : null;
 $blockZone = isset($aCapping['block_zone']) ? $aCapping['block_zone'] : null;
-$showCappedNoCookie = (bool)$aCapping['show_capped_no_cookie_zone'];
+$showCappedNoCookie = !empty($aCapping['show_capped_no_cookie_zone']);
 return (_limitationsIsZoneCapped($zoneId, $capZone, $sessionCapZone, $blockZone, $showCappedNoCookie));
 }
 function _limitationsIsAdCapped($adId, $cap, $sessionCap = 0, $block, $showCappedNoCookie)
@@ -3166,7 +3166,7 @@ $random = MAX_getRandomNumber();
 global $cookie_random;  $cookie_random = $random;
 $clickUrl = _adRenderBuildClickUrl($aBanner, $zoneId, $source, $ct0, $logClick, true);
 $urlPrefix = substr(MAX_commonGetDeliveryUrl(), 0, -1);
-$code = str_replace('{clickurl}', $clickUrl, $code);
+$code = str_replace('{clickurl}', $clickUrl, $code); 
 if (strpos($code, '{logurl}') !== false) {
 $logUrl = _adRenderBuildLogURL($aBanner, $zoneId, $source, $loc, $referer, '&');
 $code = str_replace('{logurl}', $logUrl, $code);  }
@@ -4092,8 +4092,7 @@ if (MAX_limitationsIsAdForbidden($aAd)) {
 OX_Delivery_logMessage('MAX_limitationsIsAdForbidden = true for bannerid '.$aAd['ad_id'], 7);
 return false;
 }
-if ($GLOBALS['_MAX']['SSL_REQUEST'] && $aAd['type'] == 'html' &&
-(($aAd['adserver'] != 'max' && $aAd['adserver'] != '3rdPartyServers:ox3rdPartyServers:max') || $aAd['html_ssl_unsafe'])) {
+if ($GLOBALS['_MAX']['SSL_REQUEST'] && $aAd['type'] == 'html' && $aAd['html_ssl_unsafe']) {
 OX_Delivery_logMessage('"http:" on SSL found for html bannerid '.$aAd['ad_id'], 7);
 return false;
 }

--- a/www/delivery/apu.php
+++ b/www/delivery/apu.php
@@ -159,7 +159,7 @@ $GLOBALS['_MAX']['MAX_COOKIELESS_PREFIX'] = '__';
 $GLOBALS['_MAX']['thread_id'] = uniqid();
 $GLOBALS['_MAX']['SSL_REQUEST'] = false;
 if (
-(!empty($_SERVER['SERVER_PORT']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
+(!empty($_SERVER['SERVER_PORT']) && !empty($GLOBALS['_MAX']['CONF']['openads']['sslPort']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
 (!empty($_SERVER['HTTPS']) && ((strtolower($_SERVER['HTTPS']) == 'on') || ($_SERVER['HTTPS'] == 1))) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && (strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https')) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_SSL']) && (strtolower($_SERVER['HTTP_X_FORWARDED_SSL']) == 'on')) ||
@@ -257,9 +257,9 @@ setupDeliveryConfigVariables();
 $conf = $GLOBALS['_MAX']['CONF'];
 $GLOBALS['_OA']['invocationType'] = array_search(basename($_SERVER['SCRIPT_FILENAME']), $conf['file']);
 if (!empty($conf['debug']['production'])) {
-error_reporting(E_ALL ^ E_NOTICE ^ E_WARNING ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_NOTICE | E_WARNING | E_DEPRECATED | E_STRICT));
 } else {
-error_reporting(E_ALL ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_DEPRECATED | E_STRICT));
 }
 
 $file = '/lib/max/Delivery/common.php';
@@ -3096,7 +3096,7 @@ function MAX_limitationsIsZoneForbidden($zoneId, $aCapping)
 $capZone = isset($aCapping['cap_zone']) ? $aCapping['cap_zone'] : null;
 $sessionCapZone = isset($aCapping['session_cap_zone']) ? $aCapping['session_cap_zone'] : null;
 $blockZone = isset($aCapping['block_zone']) ? $aCapping['block_zone'] : null;
-$showCappedNoCookie = (bool)$aCapping['show_capped_no_cookie_zone'];
+$showCappedNoCookie = !empty($aCapping['show_capped_no_cookie_zone']);
 return (_limitationsIsZoneCapped($zoneId, $capZone, $sessionCapZone, $blockZone, $showCappedNoCookie));
 }
 function _limitationsIsAdCapped($adId, $cap, $sessionCap = 0, $block, $showCappedNoCookie)
@@ -3166,7 +3166,7 @@ $random = MAX_getRandomNumber();
 global $cookie_random;  $cookie_random = $random;
 $clickUrl = _adRenderBuildClickUrl($aBanner, $zoneId, $source, $ct0, $logClick, true);
 $urlPrefix = substr(MAX_commonGetDeliveryUrl(), 0, -1);
-$code = str_replace('{clickurl}', $clickUrl, $code);
+$code = str_replace('{clickurl}', $clickUrl, $code); 
 if (strpos($code, '{logurl}') !== false) {
 $logUrl = _adRenderBuildLogURL($aBanner, $zoneId, $source, $loc, $referer, '&');
 $code = str_replace('{logurl}', $logUrl, $code);  }
@@ -4092,8 +4092,7 @@ if (MAX_limitationsIsAdForbidden($aAd)) {
 OX_Delivery_logMessage('MAX_limitationsIsAdForbidden = true for bannerid '.$aAd['ad_id'], 7);
 return false;
 }
-if ($GLOBALS['_MAX']['SSL_REQUEST'] && $aAd['type'] == 'html' &&
-(($aAd['adserver'] != 'max' && $aAd['adserver'] != '3rdPartyServers:ox3rdPartyServers:max') || $aAd['html_ssl_unsafe'])) {
+if ($GLOBALS['_MAX']['SSL_REQUEST'] && $aAd['type'] == 'html' && $aAd['html_ssl_unsafe']) {
 OX_Delivery_logMessage('"http:" on SSL found for html bannerid '.$aAd['ad_id'], 7);
 return false;
 }

--- a/www/delivery/avw.php
+++ b/www/delivery/avw.php
@@ -159,7 +159,7 @@ $GLOBALS['_MAX']['MAX_COOKIELESS_PREFIX'] = '__';
 $GLOBALS['_MAX']['thread_id'] = uniqid();
 $GLOBALS['_MAX']['SSL_REQUEST'] = false;
 if (
-(!empty($_SERVER['SERVER_PORT']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
+(!empty($_SERVER['SERVER_PORT']) && !empty($GLOBALS['_MAX']['CONF']['openads']['sslPort']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
 (!empty($_SERVER['HTTPS']) && ((strtolower($_SERVER['HTTPS']) == 'on') || ($_SERVER['HTTPS'] == 1))) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && (strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https')) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_SSL']) && (strtolower($_SERVER['HTTP_X_FORWARDED_SSL']) == 'on')) ||
@@ -257,9 +257,9 @@ setupDeliveryConfigVariables();
 $conf = $GLOBALS['_MAX']['CONF'];
 $GLOBALS['_OA']['invocationType'] = array_search(basename($_SERVER['SCRIPT_FILENAME']), $conf['file']);
 if (!empty($conf['debug']['production'])) {
-error_reporting(E_ALL ^ E_NOTICE ^ E_WARNING ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_NOTICE | E_WARNING | E_DEPRECATED | E_STRICT));
 } else {
-error_reporting(E_ALL ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_DEPRECATED | E_STRICT));
 }
 
 $file = '/lib/max/Delivery/common.php';
@@ -3096,7 +3096,7 @@ function MAX_limitationsIsZoneForbidden($zoneId, $aCapping)
 $capZone = isset($aCapping['cap_zone']) ? $aCapping['cap_zone'] : null;
 $sessionCapZone = isset($aCapping['session_cap_zone']) ? $aCapping['session_cap_zone'] : null;
 $blockZone = isset($aCapping['block_zone']) ? $aCapping['block_zone'] : null;
-$showCappedNoCookie = (bool)$aCapping['show_capped_no_cookie_zone'];
+$showCappedNoCookie = !empty($aCapping['show_capped_no_cookie_zone']);
 return (_limitationsIsZoneCapped($zoneId, $capZone, $sessionCapZone, $blockZone, $showCappedNoCookie));
 }
 function _limitationsIsAdCapped($adId, $cap, $sessionCap = 0, $block, $showCappedNoCookie)
@@ -3166,7 +3166,7 @@ $random = MAX_getRandomNumber();
 global $cookie_random;  $cookie_random = $random;
 $clickUrl = _adRenderBuildClickUrl($aBanner, $zoneId, $source, $ct0, $logClick, true);
 $urlPrefix = substr(MAX_commonGetDeliveryUrl(), 0, -1);
-$code = str_replace('{clickurl}', $clickUrl, $code);
+$code = str_replace('{clickurl}', $clickUrl, $code); 
 if (strpos($code, '{logurl}') !== false) {
 $logUrl = _adRenderBuildLogURL($aBanner, $zoneId, $source, $loc, $referer, '&');
 $code = str_replace('{logurl}', $logUrl, $code);  }
@@ -4092,8 +4092,7 @@ if (MAX_limitationsIsAdForbidden($aAd)) {
 OX_Delivery_logMessage('MAX_limitationsIsAdForbidden = true for bannerid '.$aAd['ad_id'], 7);
 return false;
 }
-if ($GLOBALS['_MAX']['SSL_REQUEST'] && $aAd['type'] == 'html' &&
-(($aAd['adserver'] != 'max' && $aAd['adserver'] != '3rdPartyServers:ox3rdPartyServers:max') || $aAd['html_ssl_unsafe'])) {
+if ($GLOBALS['_MAX']['SSL_REQUEST'] && $aAd['type'] == 'html' && $aAd['html_ssl_unsafe']) {
 OX_Delivery_logMessage('"http:" on SSL found for html bannerid '.$aAd['ad_id'], 7);
 return false;
 }

--- a/www/delivery/ax.php
+++ b/www/delivery/ax.php
@@ -159,7 +159,7 @@ $GLOBALS['_MAX']['MAX_COOKIELESS_PREFIX'] = '__';
 $GLOBALS['_MAX']['thread_id'] = uniqid();
 $GLOBALS['_MAX']['SSL_REQUEST'] = false;
 if (
-(!empty($_SERVER['SERVER_PORT']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
+(!empty($_SERVER['SERVER_PORT']) && !empty($GLOBALS['_MAX']['CONF']['openads']['sslPort']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
 (!empty($_SERVER['HTTPS']) && ((strtolower($_SERVER['HTTPS']) == 'on') || ($_SERVER['HTTPS'] == 1))) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && (strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https')) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_SSL']) && (strtolower($_SERVER['HTTP_X_FORWARDED_SSL']) == 'on')) ||
@@ -257,9 +257,9 @@ setupDeliveryConfigVariables();
 $conf = $GLOBALS['_MAX']['CONF'];
 $GLOBALS['_OA']['invocationType'] = array_search(basename($_SERVER['SCRIPT_FILENAME']), $conf['file']);
 if (!empty($conf['debug']['production'])) {
-error_reporting(E_ALL ^ E_NOTICE ^ E_WARNING ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_NOTICE | E_WARNING | E_DEPRECATED | E_STRICT));
 } else {
-error_reporting(E_ALL ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_DEPRECATED | E_STRICT));
 }
 
 $file = '/lib/max/Delivery/common.php';
@@ -3096,7 +3096,7 @@ function MAX_limitationsIsZoneForbidden($zoneId, $aCapping)
 $capZone = isset($aCapping['cap_zone']) ? $aCapping['cap_zone'] : null;
 $sessionCapZone = isset($aCapping['session_cap_zone']) ? $aCapping['session_cap_zone'] : null;
 $blockZone = isset($aCapping['block_zone']) ? $aCapping['block_zone'] : null;
-$showCappedNoCookie = (bool)$aCapping['show_capped_no_cookie_zone'];
+$showCappedNoCookie = !empty($aCapping['show_capped_no_cookie_zone']);
 return (_limitationsIsZoneCapped($zoneId, $capZone, $sessionCapZone, $blockZone, $showCappedNoCookie));
 }
 function _limitationsIsAdCapped($adId, $cap, $sessionCap = 0, $block, $showCappedNoCookie)
@@ -3166,7 +3166,7 @@ $random = MAX_getRandomNumber();
 global $cookie_random;  $cookie_random = $random;
 $clickUrl = _adRenderBuildClickUrl($aBanner, $zoneId, $source, $ct0, $logClick, true);
 $urlPrefix = substr(MAX_commonGetDeliveryUrl(), 0, -1);
-$code = str_replace('{clickurl}', $clickUrl, $code);
+$code = str_replace('{clickurl}', $clickUrl, $code); 
 if (strpos($code, '{logurl}') !== false) {
 $logUrl = _adRenderBuildLogURL($aBanner, $zoneId, $source, $loc, $referer, '&');
 $code = str_replace('{logurl}', $logUrl, $code);  }
@@ -4092,8 +4092,7 @@ if (MAX_limitationsIsAdForbidden($aAd)) {
 OX_Delivery_logMessage('MAX_limitationsIsAdForbidden = true for bannerid '.$aAd['ad_id'], 7);
 return false;
 }
-if ($GLOBALS['_MAX']['SSL_REQUEST'] && $aAd['type'] == 'html' &&
-(($aAd['adserver'] != 'max' && $aAd['adserver'] != '3rdPartyServers:ox3rdPartyServers:max') || $aAd['html_ssl_unsafe'])) {
+if ($GLOBALS['_MAX']['SSL_REQUEST'] && $aAd['type'] == 'html' && $aAd['html_ssl_unsafe']) {
 OX_Delivery_logMessage('"http:" on SSL found for html bannerid '.$aAd['ad_id'], 7);
 return false;
 }

--- a/www/delivery/ck.php
+++ b/www/delivery/ck.php
@@ -159,7 +159,7 @@ $GLOBALS['_MAX']['MAX_COOKIELESS_PREFIX'] = '__';
 $GLOBALS['_MAX']['thread_id'] = uniqid();
 $GLOBALS['_MAX']['SSL_REQUEST'] = false;
 if (
-(!empty($_SERVER['SERVER_PORT']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
+(!empty($_SERVER['SERVER_PORT']) && !empty($GLOBALS['_MAX']['CONF']['openads']['sslPort']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
 (!empty($_SERVER['HTTPS']) && ((strtolower($_SERVER['HTTPS']) == 'on') || ($_SERVER['HTTPS'] == 1))) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && (strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https')) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_SSL']) && (strtolower($_SERVER['HTTP_X_FORWARDED_SSL']) == 'on')) ||
@@ -257,9 +257,9 @@ setupDeliveryConfigVariables();
 $conf = $GLOBALS['_MAX']['CONF'];
 $GLOBALS['_OA']['invocationType'] = array_search(basename($_SERVER['SCRIPT_FILENAME']), $conf['file']);
 if (!empty($conf['debug']['production'])) {
-error_reporting(E_ALL ^ E_NOTICE ^ E_WARNING ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_NOTICE | E_WARNING | E_DEPRECATED | E_STRICT));
 } else {
-error_reporting(E_ALL ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_DEPRECATED | E_STRICT));
 }
 
 $file = '/lib/max/Delivery/common.php';

--- a/www/delivery/dxmlrpc.php
+++ b/www/delivery/dxmlrpc.php
@@ -159,7 +159,7 @@ $GLOBALS['_MAX']['MAX_COOKIELESS_PREFIX'] = '__';
 $GLOBALS['_MAX']['thread_id'] = uniqid();
 $GLOBALS['_MAX']['SSL_REQUEST'] = false;
 if (
-(!empty($_SERVER['SERVER_PORT']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
+(!empty($_SERVER['SERVER_PORT']) && !empty($GLOBALS['_MAX']['CONF']['openads']['sslPort']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
 (!empty($_SERVER['HTTPS']) && ((strtolower($_SERVER['HTTPS']) == 'on') || ($_SERVER['HTTPS'] == 1))) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && (strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https')) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_SSL']) && (strtolower($_SERVER['HTTP_X_FORWARDED_SSL']) == 'on')) ||
@@ -257,9 +257,9 @@ setupDeliveryConfigVariables();
 $conf = $GLOBALS['_MAX']['CONF'];
 $GLOBALS['_OA']['invocationType'] = array_search(basename($_SERVER['SCRIPT_FILENAME']), $conf['file']);
 if (!empty($conf['debug']['production'])) {
-error_reporting(E_ALL ^ E_NOTICE ^ E_WARNING ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_NOTICE | E_WARNING | E_DEPRECATED | E_STRICT));
 } else {
-error_reporting(E_ALL ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_DEPRECATED | E_STRICT));
 }
 
 $file = '/lib/max/Delivery/common.php';

--- a/www/delivery/lg.php
+++ b/www/delivery/lg.php
@@ -159,7 +159,7 @@ $GLOBALS['_MAX']['MAX_COOKIELESS_PREFIX'] = '__';
 $GLOBALS['_MAX']['thread_id'] = uniqid();
 $GLOBALS['_MAX']['SSL_REQUEST'] = false;
 if (
-(!empty($_SERVER['SERVER_PORT']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
+(!empty($_SERVER['SERVER_PORT']) && !empty($GLOBALS['_MAX']['CONF']['openads']['sslPort']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
 (!empty($_SERVER['HTTPS']) && ((strtolower($_SERVER['HTTPS']) == 'on') || ($_SERVER['HTTPS'] == 1))) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && (strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https')) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_SSL']) && (strtolower($_SERVER['HTTP_X_FORWARDED_SSL']) == 'on')) ||
@@ -257,9 +257,9 @@ setupDeliveryConfigVariables();
 $conf = $GLOBALS['_MAX']['CONF'];
 $GLOBALS['_OA']['invocationType'] = array_search(basename($_SERVER['SCRIPT_FILENAME']), $conf['file']);
 if (!empty($conf['debug']['production'])) {
-error_reporting(E_ALL ^ E_NOTICE ^ E_WARNING ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_NOTICE | E_WARNING | E_DEPRECATED | E_STRICT));
 } else {
-error_reporting(E_ALL ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_DEPRECATED | E_STRICT));
 }
 
 $file = '/lib/max/Delivery/common.php';

--- a/www/delivery/spc.php
+++ b/www/delivery/spc.php
@@ -159,7 +159,7 @@ $GLOBALS['_MAX']['MAX_COOKIELESS_PREFIX'] = '__';
 $GLOBALS['_MAX']['thread_id'] = uniqid();
 $GLOBALS['_MAX']['SSL_REQUEST'] = false;
 if (
-(!empty($_SERVER['SERVER_PORT']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
+(!empty($_SERVER['SERVER_PORT']) && !empty($GLOBALS['_MAX']['CONF']['openads']['sslPort']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
 (!empty($_SERVER['HTTPS']) && ((strtolower($_SERVER['HTTPS']) == 'on') || ($_SERVER['HTTPS'] == 1))) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && (strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https')) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_SSL']) && (strtolower($_SERVER['HTTP_X_FORWARDED_SSL']) == 'on')) ||
@@ -257,9 +257,9 @@ setupDeliveryConfigVariables();
 $conf = $GLOBALS['_MAX']['CONF'];
 $GLOBALS['_OA']['invocationType'] = array_search(basename($_SERVER['SCRIPT_FILENAME']), $conf['file']);
 if (!empty($conf['debug']['production'])) {
-error_reporting(E_ALL ^ E_NOTICE ^ E_WARNING ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_NOTICE | E_WARNING | E_DEPRECATED | E_STRICT));
 } else {
-error_reporting(E_ALL ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_DEPRECATED | E_STRICT));
 }
 
 $file = '/lib/max/Delivery/common.php';
@@ -3096,7 +3096,7 @@ function MAX_limitationsIsZoneForbidden($zoneId, $aCapping)
 $capZone = isset($aCapping['cap_zone']) ? $aCapping['cap_zone'] : null;
 $sessionCapZone = isset($aCapping['session_cap_zone']) ? $aCapping['session_cap_zone'] : null;
 $blockZone = isset($aCapping['block_zone']) ? $aCapping['block_zone'] : null;
-$showCappedNoCookie = (bool)$aCapping['show_capped_no_cookie_zone'];
+$showCappedNoCookie = !empty($aCapping['show_capped_no_cookie_zone']);
 return (_limitationsIsZoneCapped($zoneId, $capZone, $sessionCapZone, $blockZone, $showCappedNoCookie));
 }
 function _limitationsIsAdCapped($adId, $cap, $sessionCap = 0, $block, $showCappedNoCookie)
@@ -3166,7 +3166,7 @@ $random = MAX_getRandomNumber();
 global $cookie_random;  $cookie_random = $random;
 $clickUrl = _adRenderBuildClickUrl($aBanner, $zoneId, $source, $ct0, $logClick, true);
 $urlPrefix = substr(MAX_commonGetDeliveryUrl(), 0, -1);
-$code = str_replace('{clickurl}', $clickUrl, $code);
+$code = str_replace('{clickurl}', $clickUrl, $code); 
 if (strpos($code, '{logurl}') !== false) {
 $logUrl = _adRenderBuildLogURL($aBanner, $zoneId, $source, $loc, $referer, '&');
 $code = str_replace('{logurl}', $logUrl, $code);  }
@@ -4092,8 +4092,7 @@ if (MAX_limitationsIsAdForbidden($aAd)) {
 OX_Delivery_logMessage('MAX_limitationsIsAdForbidden = true for bannerid '.$aAd['ad_id'], 7);
 return false;
 }
-if ($GLOBALS['_MAX']['SSL_REQUEST'] && $aAd['type'] == 'html' &&
-(($aAd['adserver'] != 'max' && $aAd['adserver'] != '3rdPartyServers:ox3rdPartyServers:max') || $aAd['html_ssl_unsafe'])) {
+if ($GLOBALS['_MAX']['SSL_REQUEST'] && $aAd['type'] == 'html' && $aAd['html_ssl_unsafe']) {
 OX_Delivery_logMessage('"http:" on SSL found for html bannerid '.$aAd['ad_id'], 7);
 return false;
 }

--- a/www/delivery/spcjs.php
+++ b/www/delivery/spcjs.php
@@ -159,7 +159,7 @@ $GLOBALS['_MAX']['MAX_COOKIELESS_PREFIX'] = '__';
 $GLOBALS['_MAX']['thread_id'] = uniqid();
 $GLOBALS['_MAX']['SSL_REQUEST'] = false;
 if (
-(!empty($_SERVER['SERVER_PORT']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
+(!empty($_SERVER['SERVER_PORT']) && !empty($GLOBALS['_MAX']['CONF']['openads']['sslPort']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
 (!empty($_SERVER['HTTPS']) && ((strtolower($_SERVER['HTTPS']) == 'on') || ($_SERVER['HTTPS'] == 1))) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && (strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https')) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_SSL']) && (strtolower($_SERVER['HTTP_X_FORWARDED_SSL']) == 'on')) ||
@@ -257,9 +257,9 @@ setupDeliveryConfigVariables();
 $conf = $GLOBALS['_MAX']['CONF'];
 $GLOBALS['_OA']['invocationType'] = array_search(basename($_SERVER['SCRIPT_FILENAME']), $conf['file']);
 if (!empty($conf['debug']['production'])) {
-error_reporting(E_ALL ^ E_NOTICE ^ E_WARNING ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_NOTICE | E_WARNING | E_DEPRECATED | E_STRICT));
 } else {
-error_reporting(E_ALL ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_DEPRECATED | E_STRICT));
 }
 
 $file = '/lib/max/Delivery/common.php';

--- a/www/delivery/ti.php
+++ b/www/delivery/ti.php
@@ -159,7 +159,7 @@ $GLOBALS['_MAX']['MAX_COOKIELESS_PREFIX'] = '__';
 $GLOBALS['_MAX']['thread_id'] = uniqid();
 $GLOBALS['_MAX']['SSL_REQUEST'] = false;
 if (
-(!empty($_SERVER['SERVER_PORT']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
+(!empty($_SERVER['SERVER_PORT']) && !empty($GLOBALS['_MAX']['CONF']['openads']['sslPort']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
 (!empty($_SERVER['HTTPS']) && ((strtolower($_SERVER['HTTPS']) == 'on') || ($_SERVER['HTTPS'] == 1))) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && (strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https')) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_SSL']) && (strtolower($_SERVER['HTTP_X_FORWARDED_SSL']) == 'on')) ||
@@ -257,9 +257,9 @@ setupDeliveryConfigVariables();
 $conf = $GLOBALS['_MAX']['CONF'];
 $GLOBALS['_OA']['invocationType'] = array_search(basename($_SERVER['SCRIPT_FILENAME']), $conf['file']);
 if (!empty($conf['debug']['production'])) {
-error_reporting(E_ALL ^ E_NOTICE ^ E_WARNING ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_NOTICE | E_WARNING | E_DEPRECATED | E_STRICT));
 } else {
-error_reporting(E_ALL ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_DEPRECATED | E_STRICT));
 }
 
 $file = '/lib/max/Delivery/common.php';

--- a/www/delivery/tjs.php
+++ b/www/delivery/tjs.php
@@ -159,7 +159,7 @@ $GLOBALS['_MAX']['MAX_COOKIELESS_PREFIX'] = '__';
 $GLOBALS['_MAX']['thread_id'] = uniqid();
 $GLOBALS['_MAX']['SSL_REQUEST'] = false;
 if (
-(!empty($_SERVER['SERVER_PORT']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
+(!empty($_SERVER['SERVER_PORT']) && !empty($GLOBALS['_MAX']['CONF']['openads']['sslPort']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
 (!empty($_SERVER['HTTPS']) && ((strtolower($_SERVER['HTTPS']) == 'on') || ($_SERVER['HTTPS'] == 1))) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && (strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https')) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_SSL']) && (strtolower($_SERVER['HTTP_X_FORWARDED_SSL']) == 'on')) ||
@@ -257,9 +257,9 @@ setupDeliveryConfigVariables();
 $conf = $GLOBALS['_MAX']['CONF'];
 $GLOBALS['_OA']['invocationType'] = array_search(basename($_SERVER['SCRIPT_FILENAME']), $conf['file']);
 if (!empty($conf['debug']['production'])) {
-error_reporting(E_ALL ^ E_NOTICE ^ E_WARNING ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_NOTICE | E_WARNING | E_DEPRECATED | E_STRICT));
 } else {
-error_reporting(E_ALL ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_DEPRECATED | E_STRICT));
 }
 
 $file = '/lib/max/Delivery/common.php';

--- a/www/delivery/tv.php
+++ b/www/delivery/tv.php
@@ -159,7 +159,7 @@ $GLOBALS['_MAX']['MAX_COOKIELESS_PREFIX'] = '__';
 $GLOBALS['_MAX']['thread_id'] = uniqid();
 $GLOBALS['_MAX']['SSL_REQUEST'] = false;
 if (
-(!empty($_SERVER['SERVER_PORT']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
+(!empty($_SERVER['SERVER_PORT']) && !empty($GLOBALS['_MAX']['CONF']['openads']['sslPort']) && ($_SERVER['SERVER_PORT'] == $GLOBALS['_MAX']['CONF']['openads']['sslPort'])) ||
 (!empty($_SERVER['HTTPS']) && ((strtolower($_SERVER['HTTPS']) == 'on') || ($_SERVER['HTTPS'] == 1))) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && (strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https')) ||
 (!empty($_SERVER['HTTP_X_FORWARDED_SSL']) && (strtolower($_SERVER['HTTP_X_FORWARDED_SSL']) == 'on')) ||
@@ -257,9 +257,9 @@ setupDeliveryConfigVariables();
 $conf = $GLOBALS['_MAX']['CONF'];
 $GLOBALS['_OA']['invocationType'] = array_search(basename($_SERVER['SCRIPT_FILENAME']), $conf['file']);
 if (!empty($conf['debug']['production'])) {
-error_reporting(E_ALL ^ E_NOTICE ^ E_WARNING ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_NOTICE | E_WARNING | E_DEPRECATED | E_STRICT));
 } else {
-error_reporting(E_ALL ^ E_DEPRECATED);
+error_reporting(E_ALL & ~(E_DEPRECATED | E_STRICT));
 }
 
 $file = '/lib/max/Delivery/common.php';


### PR DESCRIPTION
Fixes #22.

Had to regenerate all delivery scripts, so the diff is a bit ugly...
