### PR TITLE
Fix OX-6003 3rd Party Doubleclick and OpenX click tracking broken

### DIFF
--- a/lib/OX/Extension/invocationTags/InvocationTags.php
+++ b/lib/OX/Extension/invocationTags/InvocationTags.php
@@ -185,7 +185,7 @@ class Plugins_InvocationTags extends OX_Component
 
         $mi->macros = array(
             'cachebuster' => 'INSERT_RANDOM_NUMBER_HERE',
-            'clickurl'  => 'INSERT_CLICKURL_HERE',
+            'clickurl'    => 'INSERT_ENCODED_CLICKURL_HERE',
         );
         if (!empty($mi->thirdpartytrack) && ($mi->thirdpartytrack != 'generic')) {
             if ($thirdpartyserver = OX_Component::factoryByComponentIdentifier($mi->thirdpartytrack)) {

--- a/plugins_repo/openX3rdPartyServers/plugins/3rdPartyServers/ox3rdPartyServers/max.class.php
+++ b/plugins_repo/openX3rdPartyServers/plugins/3rdPartyServers/ox3rdPartyServers/max.class.php
@@ -28,7 +28,7 @@ require_once LIB_PATH . '/Extension/3rdPartyServers/3rdPartyServers.php';
 class Plugins_3rdPartyServers_ox3rdPartyServers_max extends Plugins_3rdPartyServers
 {
     var $hasOutputMacros = true;
-    var $clickurlMacro = '{clickurl}';
+    var $clickurlMacro = '{clickurl_enc}';
     var $cachebusterMacro = '{random}';
 
     /**
@@ -48,8 +48,8 @@ class Plugins_3rdPartyServers_ox3rdPartyServers_max extends Plugins_3rdPartyServ
      */
     function getBannerCache($buffer, &$noScript)
     {
-        $search  = array("/insert_random_number_here/i", "/insert_click_?(track_|_)?url_here/i");
-        $replace = array("{random}", "{clickurl}");
+        $search  = array("/insert_random_number_here/i", "/insert_(?:encoded_)?click_?(?:track_|_)?url_here/i");
+        $replace = array("{random}", "{clickurl_enc}");
 
         $buffer = preg_replace($search, $replace, $buffer);
         $noScript[0] = preg_replace($search, $replace, $noScript[0]);

--- a/plugins_repo/openXInvocationTags/plugins/invocationTags/oxInvocationTags/adjs.class.php
+++ b/plugins_repo/openXInvocationTags/plugins/invocationTags/oxInvocationTags/adjs.class.php
@@ -142,7 +142,7 @@ class Plugins_InvocationTags_OxInvocationTags_adjs extends Plugins_InvocationTag
         if (!empty($mi->thirdpartytrack)) {
             // Don't pass this in as a parameter... it is dealt with seperatly
             unset($mi->parameters['ct0']);
-            $buffer .= "   document.MAX_ct0 ='{$mi->macros['clickurl']}';\n\n";
+            $buffer .= "   document.MAX_ct0 = unescape('{$mi->macros['clickurl']}');\n\n";
         }
         $buffer .= "   var m3_u = (location.protocol=='https:'?'https:".MAX_commonConstructPartialDeliveryUrl($conf['file']['js'], true)."':'http:".MAX_commonConstructPartialDeliveryUrl($conf['file']['js'])."');\n";
         $buffer .= "   var m3_r = Math.floor(Math.random()*99999999999);\n";


### PR DESCRIPTION
> From https://developer.openx.org/jira/browse/OX-6003

Generating invocation tags with 3rd party click tracking enabled is broken in many ways:
- Most of the invocation types, apart from JS, expect the clicktrack URL to be urlencoded, as the placeholder is inside an URL
- JS invocation expects the placeholder to be replaced with an unencoded string as it performs its own encoding
- Doubleclick's %c placeholder is replaced with an encoded string, so it works with anything but JS
- OpenX's INSERT_ is replaced with an unencoded string, so it works only with JS

The attached patch is meant to clean up the situation a bit by:
- Fixing JS invocation so that the placeholder is expected to be escaped
- Fixing OpenX's 3rd party plugin so that its placeholder is replaced with {clickurl_enc}
- Changing the generic placeholder to INSERT_ENCODED_CLICKURL_HERE, so that it's obvious what the content ought to be
#### I'm not sure this fix is 100% ok. Will need some thorough testing.
