### PR TITLE
Fix OX-5996 SQL stored banners not working on PostgreSQL

### DIFF
--- a/lib/OA/Dal/Delivery.php
+++ b/lib/OA/Dal/Delivery.php
@@ -917,6 +917,7 @@ function OA_Dal_Delivery_getCreative($filename)
         return (defined('OA_DELIVERY_CACHE_FUNCTION_ERROR')) ? OA_DELIVERY_CACHE_FUNCTION_ERROR : null;
     } else {
         $aResult = OA_Dal_Delivery_fetchAssoc($rCreative);
+        $aResult['contents'] = OX_unescapeBlob($aResult['contents']);
         $aResult['t_stamp'] = strtotime($aResult['t_stamp'] . ' GMT');
         return ($aResult);
     }

--- a/lib/OA/Dal/Delivery/mysql.php
+++ b/lib/OA/Dal/Delivery/mysql.php
@@ -147,6 +147,11 @@ function OX_escapeString($string)
     return mysql_real_escape_string($string);
 }
 
+function OX_unescapeBlob($blob)
+{
+    return $blob;
+}
+
 function OX_escapeIdentifier($string)
 {
     return '`'.$string.'`';

--- a/lib/OA/Dal/Delivery/pgsql.php
+++ b/lib/OA/Dal/Delivery/pgsql.php
@@ -155,6 +155,11 @@ function OX_escapeIdentifier($string)
     return '"'.$string.'"';
 }
 
+function OX_unescapeBlob($blob)
+{
+    return pg_unescape_bytea($blob);
+}
+
 function OX_Dal_Delivery_regex($column, $regexp)
 {
     return $column." ~* E'".$regexp."'";


### PR DESCRIPTION
> From https://developer.openx.org/jira/browse/OX-5996

It appears that since the separate delivery DALs (mysql.php / pgsql.php) were merged into a single file, a bug slipped in that prevents SQL stored banners from being properly returned when PostgreSQL is used, as there's a missing pg_unescape_bytea() call. 
