### PR TITLE
Fix OX-5992 SWF banners overlap website content

### DIFF
--- a/lib/max/Delivery/adRender.php
+++ b/lib/max/Delivery/adRender.php
@@ -350,6 +350,8 @@ function _adRenderFlash(&$aBanner, $zoneId=0, $source='', $ct0='', $withText=fal
     }
     if (!empty($aBanner['transparent'])) {
         $code .= "\n   ox_swf.addParam('wmode','transparent');";
+    } else {
+        $code .= "\n   ox_swf.addParam('wmode','opaque');";
     }
     $code .= "
     ox_swf.addParam('allowScriptAccess','always');


### PR DESCRIPTION
Opaque wmode should be the default

From: https://developer.openx.org/jira/browse/OX-5992

Unless transparent, all the SWF banners should be server with wmode=opaque to prevent the browsers to render them on top of other dynamic content (i.e. menus, dropdowns, etc.) 
