### PR TITLE
Update admin-search.php to prevent from molesting db without reason

### DIFF
--- a/lib/OA/Admin/UI/Search.php
+++ b/lib/OA/Admin/UI/Search.php
@@ -26,6 +26,8 @@ class OA_Admin_UI_Search extends OA_Admin_UI
         foreach($params as $key => $val){
             $this->oTpl->assign($key, htmlentities($val));
         }
+
+        parent::showHeader(0);
     }
 }
 

--- a/lib/OA/Admin/UI/Search.php
+++ b/lib/OA/Admin/UI/Search.php
@@ -19,11 +19,13 @@ class OA_Admin_UI_Search extends OA_Admin_UI
         $this->oTpl = new OA_Admin_Template('layout/search.html');
     }
 
-    function showHeader($keyword)
+    function showHeader($keyword,$params=array())
     {
         $this->oTpl->assign('keyword', $keyword);
 
-        parent::showHeader(0);
+        foreach($params as $key => $val){
+            $this->oTpl->assign($key, htmlentities($val));
+        }
     }
 }
 

--- a/lib/templates/admin/layout/search.html
+++ b/lib/templates/admin/layout/search.html
@@ -44,7 +44,7 @@
 {include file=layout/branding.html}
 
 	<div id='oaSearch'>
-		<form name='search' action='admin-search.php' method='post'>
+		<form name='search' action='admin-search.php' method='get'>
 	    <input type='hidden' name='client' value='{$client}'>
 	    <input type='hidden' name='campaign' value='{$campaign}'>
 	    <input type='hidden' name='banner' value='{$banner}'>

--- a/www/admin/admin-search.php
+++ b/www/admin/admin-search.php
@@ -32,18 +32,6 @@ if (!isset($banner) || ($banner != 't'))        $banner = false;
 if (!isset($zone) || ($zone != 't'))            $zone = false;
 if (!isset($affiliate) || ($affiliate != 't'))  $affiliate = false;
 
-
-if ($client == false &&    $campaign == false &&
-    $banner == false &&    $zone == false &&
-    $affiliate == false)
-{
-    $client = true;
-    $campaign = true;
-    $banner = true;
-    $zone = true;
-    $affiliate = true;
-}
-
 if (!isset($compact)) {
     $compact = false;
 }

--- a/www/admin/admin-search.php
+++ b/www/admin/admin-search.php
@@ -190,7 +190,7 @@ $oTpl->assign('aZones', $aZones);
 
 $oUI = new OA_Admin_UI_Search();
 
-$oUI->showHeader($keyword);
+$oUI->showHeader($keyword, $_GET);
 $oTpl->display();
 $oUI->showFooter();
 


### PR DESCRIPTION
Currently every time user searches something, it will search everywhere without letting user choose what type of search he wants. 
After it loads all search results - user will choose search type and it will search again. 
If users won't provide keyword to search it will output everything from a DB. On very large DBs it may take hours and slow down server a lot.

It's also an easy way to kill db server.

But main reason... such code just shouldn't be there :)
