### PR TITLE
Fix code injection vulnerability in delivery limitations

### DIFF
--- a/lib/OX/Extension/deliveryLimitations/DeliveryLimitations.php
+++ b/lib/OX/Extension/deliveryLimitations/DeliveryLimitations.php
@@ -294,7 +294,7 @@ class Plugins_DeliveryLimitations extends OX_Component
      */
     function compileData($data)
     {
-        return 'MAX_check' . ucfirst($this->group) . '_' . $this->component . "('{$data}', '{$this->comparison}')";
+        return 'MAX_check' . ucfirst($this->group) . '_' . $this->component . "('".addslashes($data)."', '".addslashes($this->comparison)."')";
     }
 
     /**


### PR DESCRIPTION
There is a a code injection vulnerability in the handling of delivery limitations which allows arbitrary code execution for  a subset of registered users. This vulnerability is already being actively exploited (I discovered it upon investigating an intrusion into an ad server). This change fixes it.

Not surprisingly, OpenX 2.8.11 is affected by this vulnerability as well. The fix can be easily adapted for OpenX (see http://www.kreativrauschen.com/blog/2013/09/11/zero-day-vulnerability-in-openx-2-8-11/ for the OpenX code).

I do not want to publish an explicit proof-of-concept exploit (even though it is already being exploited we do not need to make it too easy for the bad guys ^_^), but maintainers of the master repository can contact me privately if they need more information about how to exploit the vulnerability.
