### PR TITLE
Fix stats for PHP 5.4

### DIFF
--- a/lib/OA/Admin/Statistics/Delivery/CommonHistory.php
+++ b/lib/OA/Admin/Statistics/Delivery/CommonHistory.php
@@ -142,7 +142,7 @@ class OA_Admin_Statistics_Delivery_CommonHistory extends OA_Admin_Statistics_Del
      */
     function prepare(&$aParams, $link = '')
     {
-        parent::prepare(&$aParams);
+        parent::prepare($aParams);
         
         // Set the span requirements
         // Disable this for now, since these queries can be very slow


### PR DESCRIPTION
Call-time pass-by-reference has been removed in php5.4
