### PR TITLE
Editing an email zone always unlinks banners

### DIFF
--- a/www/admin/zone-edit.php
+++ b/www/admin/zone-edit.php
@@ -311,7 +311,7 @@ function processForm($form, $oComponent = null)
             // before we commit any changes to db, store whether the size has changed
             $aZone = Admin_DA::getZone($aFields['zoneid']);
             $size_changed = ($aFields['width'] != $aZone['width'] || $aFields['height'] != $aZone['height']) ? true : false;
-            $type_changed = ($aFields['delivery'] != $aZone['delivery']) ? true : false;
+            $type_changed = ($aFields['delivery'] != $aZone['type']) ? true : false;
 
             $doZones = OA_Dal::factoryDO('zones');
             $doZones->zonename = $aFields['zonename'];


### PR DESCRIPTION
SQLBuilder uses name 'type' for field (zone-edit.php form name delivery)
