### PR TITLE
Performance: flush PHP output buffers before DB logging

### DIFF
--- a/www/delivery_dev/lg.php
+++ b/www/delivery_dev/lg.php
@@ -50,6 +50,19 @@ $aCapZone['capping']             = MAX_Delivery_log_getArrGetVariable('capZone')
 $aCapZone['session_capping']     = MAX_Delivery_log_getArrGetVariable('sessionCapZone');
 $aSetLastSeen                    = MAX_Delivery_log_getArrGetVariable('lastView');
 
+MAX_cookieFlush();
+MAX_querystringConvertParams();
+
+if (!empty($_REQUEST[$GLOBALS['_MAX']['CONF']['var']['dest']])) {
+    MAX_redirect($_REQUEST[$GLOBALS['_MAX']['CONF']['var']['dest']]);
+} else {
+    // Display a 1x1 pixel gif
+    MAX_commonDisplay1x1();
+}
+
+// Done generating output so flush it while doing logging and maintenance.
+flush();
+
 // Loop over the ads to be logged (there may be more than one due to internal re-directs)
 // and log each ad, and th  en set any capping cookies required
 $countAdIds = count($aAdIds);
@@ -76,16 +89,6 @@ for ($index = 0; $index < $countAdIds; $index++) {
             }
         }
     }
-}
-
-MAX_cookieFlush();
-MAX_querystringConvertParams();
-
-if (!empty($_REQUEST[$GLOBALS['_MAX']['CONF']['var']['dest']])) {
-    MAX_redirect($_REQUEST[$GLOBALS['_MAX']['CONF']['var']['dest']]);
-} else {
-    // Display a 1x1 pixel gif
-    MAX_commonDisplay1x1();
 }
 
 // Run automaintenance, if needed


### PR DESCRIPTION
This change calls flush() before logging the ad impression. On my setup (Apache, with gzip compression off) this starts sending the output to the client while the logging is happening. This reduces the latency of the lg.php calls.

On OpenX 2.8 (where I first made the change) I got about a 20% reduction in latency with this change.
