### PR TITLE
Update advertiser-index.php

### DIFF
--- a/www/admin/advertiser-index.php
+++ b/www/admin/advertiser-index.php
@@ -106,6 +106,7 @@ elseif (OA_Permission::isAccount(OA_ACCOUNT_MANAGER)) {
         foreach ($banners as &$banner) {
             $banner['status'] = $banner['active'];
         }
+        unset($banner);
     }
 }
 


### PR DESCRIPTION
The $banner variable in the foreach reference loop must be unset to avoid an active advertiser appearing inactive when the $banner variable is used for building the advertiser tree. 

See the warning on http://php.net/manual/en/control-structures.foreach.php :
"Reference of a $value and the last array element remain even after the foreach loop. It is recommended to destroy it by unset()."
