### PR TITLE
Process extra parameters when generating tags through APIv2

### DIFF
--- a/www/api/v2/xmlrpc/ZoneXmlRpcService.php
+++ b/www/api/v2/xmlrpc/ZoneXmlRpcService.php
@@ -427,6 +427,11 @@ class ZoneXmlRpcService extends BaseZoneService
                 array(true, true, true, false), $oParams, $oResponseWithError)) {
            return $oResponseWithError;
         }
+        
+        if (!XmlRpcUtils::getNotRequiredNonScalarValue(
+                &$aParams, &$oParams, 3, $oResponseWithError)) {
+           return $oResponseWithError;
+        }
 
         if ($this->_oZoneServiceImp->generateTags($sessionId, $zoneId, $codeType, $aParams, $generatedTag)) {
             return XmlRpcUtils::stringTypeResponse($generatedTag);


### PR DESCRIPTION
Because the generateTags() call was expecting a struct or array as the third "params" argument, the use of getScalarValues resulted in these parameters being completely ignored. This change uses getNotRequiredScalarValue() to correctly parse the incoming struct or array parameters and pass them on.

This allows the XML call to include $aParams values like array('comments' => 0) to disable comments in the resulting invocation tag, etc.
