### PR TITLE
fix #316 wrong charset for campaign-zone-zones.php etc

### DIFF
--- a/www/admin/account-switch-search.php
+++ b/www/admin/account-switch-search.php
@@ -30,6 +30,9 @@ require_once MAX_PATH . '/www/admin/config.php';
 require_once MAX_PATH . '/lib/OA/Admin/Template.php';
 require_once MAX_PATH . '/lib/OA/Admin/UI/AccountSwitch.php';
 
+// Send header with charset info
+header ("Content-Type: text/html".(isset($phpAds_CharSet) && $phpAds_CharSet != "" ? "; charset=".$phpAds_CharSet : ""));
+
 $oTpl = new OA_Admin_Template('account-switch-search.html');
 OA_Admin_UI_AccountSwitch::assignModel($oTpl, $q);
 $oTpl->display();

--- a/www/admin/campaign-zone-link.php
+++ b/www/admin/campaign-zone-link.php
@@ -20,6 +20,10 @@ require_once MAX_PATH . '/www/admin/config.php';
 /*-------------------------------------------------------*/
 /* Main code                                             */
 /*-------------------------------------------------------*/
+
+// Send header with charset info
+header ("Content-Type: text/html".(isset($phpAds_CharSet) && $phpAds_CharSet != "" ? "; charset=".$phpAds_CharSet : ""));
+
 require_once MAX_PATH . '/lib/OA/Admin/Template.php';
 require_once MAX_PATH . '/lib/OA/Admin/UI/CampaignZoneLink.php';
 

--- a/www/admin/campaign-zone-zones.php
+++ b/www/admin/campaign-zone-zones.php
@@ -25,6 +25,9 @@ OA_Permission::enforceAccessToObject ( 'campaigns', $campaignid );
 /* Main code                                             */
 /*-------------------------------------------------------*/
 
+// Send header with charset info
+header ("Content-Type: text/html".(isset($phpAds_CharSet) && $phpAds_CharSet != "" ? "; charset=".$phpAds_CharSet : ""));
+
 require_once MAX_PATH . '/lib/OA/Admin/Template.php';
 require_once MAX_PATH . '/lib/OA/Admin/UI/CampaignZoneLink.php';
 


### PR DESCRIPTION
If apache (AddDefaultCharset-option) or nginx (charset-option) is configured to a different charset than $phpAds_CharSet, then the non-ascii chars in zonenames as displayed incorrectly when viewing e.g. "/www/admin/campaign-zone.php?clientid=XXX&campaignid=YYY".

It's fixed by just adding:

``` php
// Send header with charset info
header ("Content-Type: text/html".(isset($phpAds_CharSet) && $phpAds_CharSet != "" ? "; charset=".$phpAds_CharSet : ""));
```

Similar to what is in admin-search.php

This fix also needs to be applied to "campaign-zone-link.php" and other places which get data through AJAX.
