### PR TITLE
Removed what appears to be dead/unreachable code within constants.php an...

### DIFF
--- a/constants.php
+++ b/constants.php
@@ -205,29 +205,11 @@ function setupConstants()
         if (!defined('RV_PATH')) {
             define('RV_PATH', MAX_PATH);
         }
-        // Ensure that the DIRECTORY_SEPARATOR and PATH_SEPARATOR
-        // constants are correctly defined
-        if (!defined('DIRECTORY_SEPARATOR')) {
-            if (strpos($_ENV['OS'], 'Win') !== false) {
-                // Windows
-                define('DIRECTORY_SEPARATOR', '/');
-            } else {
-                // UNIX
-                define('DIRECTORY_SEPARATOR', '\\');
-            }
-        }
-        if (!defined('PATH_SEPARATOR')) {
-            if (strpos($_ENV['OS'], 'Win') !== false) {
-                // Windows
-                define('PATH_SEPARATOR', ';');
-            } else {
-                // UNIX
-                define('PATH_SEPARATOR', ':');
-            }
-        }
         if (!defined('LIB_PATH')) {
             define('LIB_PATH', MAX_PATH. DIRECTORY_SEPARATOR. 'lib'. DIRECTORY_SEPARATOR. 'OX');
         }
+
+        define('IS_WINDOWS', (DIRECTORY_SEPARATOR === '\\'));
 
         // Setup the include path
         setupIncludePath();


### PR DESCRIPTION
...d added a new IS_WINDOWS constant.

Reasoning behind the removal:
- DIRECTORY_SEPARATOR is always defined (at least according to the PHP manual)
- PATH_SEPARATOR exists since php 4.3.0, and Revive requires PHP 5.1.4+ at the very least so...

Source: http://www.php.net/manual/en/dir.constants.php
