### PR TITLE
Ref #65, #116 - add exception for php >= 5.4.4-14+deb7u9

### DIFF
--- a/lib/OA/Upgrade/EnvironmentManager.php
+++ b/lib/OA/Upgrade/EnvironmentManager.php
@@ -376,7 +376,23 @@ class OA_Environment_Manager
                 '5.4.20',
                 "<"
             )) {
-                $result = OA_ENV_ERROR_PHP_VERSION_54;
+                /*
+                 * debian has backported the bugfix for [1], so the updates from debian wheezy are ok
+                 *
+                 * references:
+                 *   [1] https://bugs.php.net/bug.php?id=65367
+                 *   [2] https://github.com/revive-adserver/revive-adserver/issues/65
+                 *   [3] https://github.com/revive-adserver/revive-adserver/issues/116
+                 */
+                if (version_compare(
+                    $this->aInfo['PHP']['actual']['version'],
+                    '5.4.4-14+deb7u9',
+                    '>='
+                )) {
+                    $result = OA_ENV_ERROR_PHP_NOERROR;
+                } else {
+                    $result = OA_ENV_ERROR_PHP_VERSION_54;
+                }
             } elseif (version_compare(
                 $this->aInfo['PHP']['actual']['version'],
                 '5.5.0',


### PR DESCRIPTION
Because debian backported patches from 5.4.20 to 5.4.4, which includes the patch for #65, the installer/upgrader can ignore everything higher than php version  5.4.4-14+deb7u9. See also http://metadata.ftp-master.debian.org/changelogs//main/p/php5/php5_5.4.4-14+deb7u11_changelog.
