### PR TITLE
Removed document.write and changed the OA_show function

### DIFF
--- a/www/delivery/spc.php
+++ b/www/delivery/spc.php
@@ -4303,7 +4303,7 @@ return '"'.$string.'"';
 MAX_commonSetNoCacheHeaders();
 MAX_commonRegisterGlobalsArray(array('zones' ,'source', 'block', 'blockcampaign', 'exclude', 'mmm_fo', 'q', 'nz'));
 $source = MAX_commonDeriveSource($source);
-$spc_output = 'var ' . $conf['var']['prefix'] . 'output = new Array(); ' . "\n";
+$spc_output = 'var ' . $conf['var']['prefix'] . 'output = new Object(); ' . "\n";
 if(!empty($zones)) {
 $zones = explode('|', $zones);
 foreach ($zones as $thisZone) {
@@ -4335,4 +4335,6 @@ $context[] = $contextArray;
 }
 MAX_cookieFlush();
 MAX_commonSendContentTypeHeader("application/x-javascript", $charset);
+$spc_output = "window.".$conf['var']['prefix'] ."output=". $spc_output;
+header("Content-Length: ".strlen($spc_output));
 echo $spc_output;

--- a/www/delivery/spcjs.php
+++ b/www/delivery/spcjs.php
@@ -3158,11 +3158,11 @@ if ($key == 'id') { continue; }
 if ($magic_quotes_gpc) { $value = stripslashes($value); }
 $additionalParams .= htmlspecialchars('&'.urlencode($key).'='.urlencode($value), ENT_QUOTES);
 }
-$script = "
+$script = "var head = document.head || document.getElementsByTagName( 'head' )[0] || document.documentElement;
     if (typeof({$varprefix}zones) != 'undefined') {
         var {$varprefix}zoneids = '';
         for (var zonename in {$varprefix}zones) {$varprefix}zoneids += escape(zonename+'=' + {$varprefix}zones[zonename] + \"|\");
-        {$varprefix}zoneids += '&amp;nz=1';
+        {$varprefix}zoneids += '&nz=1';
     } else {
         var {$varprefix}zoneids = escape('" . implode('|', array_keys($aZones)) . "');
     }
@@ -3173,27 +3173,30 @@ MAX_commonConstructSecureDeliveryUrl($aConf['file']['singlepagecall'], true).
 "':'".
 MAX_commonConstructDeliveryUrl($aConf['file']['singlepagecall'])."';
     var {$varprefix}r=Math.floor(Math.random()*99999999);
-    {$varprefix}output = new Array();
+    {$varprefix}output = new Object();
 
-    var {$varprefix}spc=\"<\"+\"script type='text/javascript' \";
-    {$varprefix}spc+=\"src='\"+{$varprefix}p+\"?zones=\"+{$varprefix}zoneids;
-    {$varprefix}spc+=\"&amp;source=\"+escape({$varprefix}source)+\"&amp;r=\"+{$varprefix}r;" .
+      var {$varprefix}spc = {$varprefix}p+\"?zones=\"+{$varprefix}zoneids;
+    {$varprefix}spc+=\"&source=\"+escape({$varprefix}source)+\"&r=\"+{$varprefix}r;" .
 ((!empty($additionalParams)) ? "\n    {$varprefix}spc+=\"{$additionalParams}\";" : '') . "
     ";
 if (empty($_GET['charset'])) {
-$script .= "{$varprefix}spc+=(document.charset ? '&amp;charset='+document.charset : (document.characterSet ? '&amp;charset='+document.characterSet : ''));\n";
+$script .= "{$varprefix}spc+=(document.charset ? '&charset='+document.charset : (document.characterSet ? '&charset='+document.characterSet : ''));\n";
 }
 $script .= "
-    if (window.location) {$varprefix}spc+=\"&amp;loc=\"+escape(window.location);
-    if (document.referrer) {$varprefix}spc+=\"&amp;referer=\"+escape(document.referrer);
-    {$varprefix}spc+=\"'><\"+\"/script>\";
-    document.write({$varprefix}spc);
+    if (window.location) {$varprefix}spc+=\"&loc=\"+escape(window.location);
+    if (document.referrer) {$varprefix}spc+=\"&referer=\"+escape(document.referrer);
 
-    function {$varprefix}show(name) {
+    var script = document.createElement('script');
+    script.type = 'text/javascript';
+    script.src = {$varprefix}spc;
+
+    head.insertBefore(script,head.firstChild);
+
+    function {$varprefix}show(id,name) {
         if (typeof({$varprefix}output[name]) == 'undefined') {
             return;
         } else {
-            document.write({$varprefix}output[name]);
+            document.getElementById(id).innerHTML = {$varprefix}output[name];
         }
     }
 


### PR DESCRIPTION
Changes:-
In spc.php, the JavaScript object that was exposed to the browser was an Array type, It must be an Object type and the Object should be in the window scope. I have taken care of these things with the changes.

In spcjs.php, Removed unnecessary '&amp;' and replaced with '&' as it won't make a difference and Instead of directly dumping the response with document.write, I am creating a script tag and inserting it into the head like <script src="spc.php link ">. So it will fetch the response and store it in the object which will be window scoped. Now publisher will pass the id as well as zone name with show function and show function will directly dump the response by doing document.getElementById.innerHTML on that particular HTML element.
