### PR TITLE
Removing action adress from login form

### DIFF
--- a/lib/templates/admin/login.html
+++ b/lib/templates/admin/login.html
@@ -12,7 +12,7 @@
 
 {if $uiEnabled}
 <br />
-<form class="login" name="login" method="post" action="{$formAction|escape}">
+<form class="login" name="login" method="post" action="">
     <input type="hidden" name="oa_cookiecheck" value="{$sessionID|escape}" />
     <table width="100%" cellpadding="0" cellspacing="0" border="0">
         <tr>


### PR DESCRIPTION
For security reasons (obscurity) I needed to change the admin panel from URL
https://example.com/ads/admin to https://example.com/ads/somethingelse. 
I did this with mod_rewrite in apache. Everything worked out except the 
action path in the login form which is not needed.
