### PR TITLE
Look for gzopen64 php function too for zlib detection.

### DIFF
--- a/lib/pclzip/pclzip.lib.php
+++ b/lib/pclzip/pclzip.lib.php
@@ -199,7 +199,7 @@
     //--(MAGIC-PclTrace)--//PclTraceFctStart(__FILE__, __LINE__, 'PclZip::PclZip', "zipname=$p_zipname");
 
     // ----- Tests the zlib
-    if (!function_exists('gzopen'))
+    if (!function_exists('gzopen') && !function_exists('gzopen64'))
     {
       //--(MAGIC-PclTrace)--//PclTraceFctMessage(__FILE__, __LINE__, 1, "zlib extension seems to be missing");
       die('Abort '.basename(__FILE__).' : Missing zlib extensions');


### PR DESCRIPTION
Fix scenario when gzip library on latest Ubuntu LTS could not be detected breaking installation.

Example:
php > var_dump( extension_loaded( 'zlib' ) );
bool(true)
php > $f = gzopen( '/tmp/test.gz', 'r' );
Fatal error: Call to undefined function gzopen() in php shell code on line 1
