### PR TITLE
fixed MAX_Admin_Invocation class for invocation tag plugin defined variables

### DIFF
--- a/lib/max/Admin/Invocation.php
+++ b/lib/max/Admin/Invocation.php
@@ -35,7 +35,7 @@ class MAX_Admin_Invocation {
         'cacheBuster'      => 1,
     );
 
-    function getAllowedVariables()
+    function getAllowedVariables(&$invocationTag = null)
     {
         $aVariables = array(
             // IDs
@@ -105,10 +105,10 @@ class MAX_Admin_Invocation {
      *
      * @param array $aParams The invocation parameters. If null, variables will be fetched from $GLOBALS
      */
-    function assignVariables($aParams = null)
+    function assignVariables($aParams = null, &$invocationTag = null)
     {
         // Get all variables
-        $globalVariables = $this->getAllowedVariables();
+        $globalVariables = $this->getAllowedVariables($invocationTag);
 
         // Check if we need to fetch variables from the global scope
         if (!isset($aParams)) {
@@ -118,7 +118,7 @@ class MAX_Admin_Invocation {
             foreach($globalVariables as $makeMeGlobal) {
                 global $$makeMeGlobal;
                 // If values are unset, populate them from the Plugin/Parent object if present
-                if (isset($$makeMeGlobal)) {
+                if (!isset($$makeMeGlobal)) {
                     // Check the plugin first, fall-back to the parent
                     if (isset($invocationTag->defaultOptionValues[$makeMeGlobal])) {
                         $$makeMeGlobal = $invocationTag->defaultOptionValues[$makeMeGlobal];
@@ -154,9 +154,6 @@ class MAX_Admin_Invocation {
     {
         $conf = $GLOBALS['_MAX']['CONF'];
 
-        // register all the variables
-        $this->assignVariables($aParams);
-
         if($invocationTag === null) {
             $invocationTag = OX_Component::factoryByComponentIdentifier($this->codetype);
         }
@@ -165,6 +162,9 @@ class MAX_Admin_Invocation {
             exit();
         }
 
+        // register all the variables
+        $this->assignVariables($aParams, $invocationTag);
+        
         // pass global variables as object attributes
         $invocationTag->setInvocation($this);
 


### PR DESCRIPTION
When writing an invocation tag plugin, realized there was partial code already to allow variables to be defined easily with $defaultOptionValues member array, but it wasn't complete.  Think this fixes it...
