### PR TITLE
Fix links for crossdomain example and video ads documentation

### DIFF
--- a/plugins_repo/openXVideoAds/plugins/bannerTypeHtml/vastInlineBannerTypeHtml/common.php
+++ b/plugins_repo/openXVideoAds/plugins/bannerTypeHtml/vastInlineBannerTypeHtml/common.php
@@ -198,16 +198,16 @@ class VideoAdsHelper
 
     static function getHelpLinkVideoPlayerConfig()
     {
-        return 'http://www.openx.org/en/docs/2.8/userguide/video+ads+player+configuration';
+        return 'http://documentation.revive-adserver.com/display/DOCS/Invocation+code#Invocationcode-InvocationcodeforInlineVideoadzoneorOverlayVideoadzone';
     }
 
     static function getHelpLinkOpenXPlugin()
     {
-        return 'http://www.openx.org/en/docs/2.8/userguide/banners+video+ads';
+        return 'http://documentation.revive-adserver.com/display/DOCS/Inline+Video+banners';
     }
 
     static function getLinkCrossdomainExample()
     {
-        return 'https://svn.openx.org/openx/trunk/www/delivery_dev/crossdomain.xml';
+        return 'https://raw.githubusercontent.com/revive-adserver/revive-adserver/master/www/delivery_dev/crossdomain.xml';
     }
 }

--- a/plugins_repo/openXVideoAds/plugins/etc/openXVideoAds.xml
+++ b/plugins_repo/openXVideoAds/plugins/etc/openXVideoAds.xml
@@ -4,13 +4,13 @@
 <plugin>
     <name>openXVideoAds</name>
     <displayName>IAB VAST Plugin</displayName>
-    <creationDate>2014-11-21</creationDate>
+    <creationDate>2015-01-23</creationDate>
     <author>Revive Adserver</author>
     <authorEmail>revive@revive-adserver.com</authorEmail>
     <authorUrl>http://www.revive-adserver.com</authorUrl>
     <license>GNU Gneral Public License v2</license>
     <description>Plugin that provides IAB VAST video ad support.</description>
-    <version>1.10.8</version>
+    <version>1.10.9</version>
     <type>extension</type>
 
     <install>

--- a/plugins_repo/openXVideoAds/plugins/etc/oxLogVast/oxLogVast.xml
+++ b/plugins_repo/openXVideoAds/plugins/etc/oxLogVast/oxLogVast.xml
@@ -4,13 +4,13 @@
 <plugin>
     <name>oxLogVast</name>
     <displayName>IAB VAST Logging Plugin</displayName>
-    <creationDate>2014-11-21</creationDate>
+    <creationDate>2015-01-23</creationDate>
     <author>Revive Adserver</author>
     <authorEmail>revive@revive-adserver.com</authorEmail>
     <authorUrl>http://www.revive-adserver.com</authorUrl>
     <license>GNU Gneral Public License v2</license>
     <description>Plugin that provides IAB VAST video ad support.</description>
-    <version>1.10.8</version>
+    <version>1.10.9</version>
     <oxversion>2.7.30-beta-rc11</oxversion>
     <extends>deliveryLog</extends>
 

--- a/plugins_repo/openXVideoAds/plugins/etc/vastInlineBannerTypeHtml/vastInlineBannerTypeHtml.xml
+++ b/plugins_repo/openXVideoAds/plugins/etc/vastInlineBannerTypeHtml/vastInlineBannerTypeHtml.xml
@@ -4,13 +4,13 @@
 <plugin>
     <name>vastInlineBannerTypeHtml</name>
     <displayName>IAB VAST Inline Banner Type Plugin</displayName>
-    <creationDate>2014-11-21</creationDate>
+    <creationDate>2015-01-23</creationDate>
     <author>Revive Adserver</author>
     <authorEmail>revive@revive-adserver.com</authorEmail>
     <authorUrl>http://www.revive-adserver.com</authorUrl>
     <license>GNU Gneral Public License v2</license>
     <description>Plugin that provides IAB VAST video ad support.</description>
-    <version>1.10.8</version>
+    <version>1.10.9</version>
     <oxversion>3.1-dev</oxversion>
     <extends>bannerTypeHtml</extends>
 

--- a/plugins_repo/openXVideoAds/plugins/etc/vastOverlayBannerTypeHtml/vastOverlayBannerTypeHtml.xml
+++ b/plugins_repo/openXVideoAds/plugins/etc/vastOverlayBannerTypeHtml/vastOverlayBannerTypeHtml.xml
@@ -4,13 +4,13 @@
 <plugin>
     <name>vastOverlayBannerTypeHtml</name>
     <displayName>IAB VAST Overlay Banner Type Plugin</displayName>
-    <creationDate>2014-11-21</creationDate>
+    <creationDate>2015-01-23</creationDate>
     <author>Revive Adserver</author>
     <authorEmail>revive@revive-adserver.com</authorEmail>
     <authorUrl>http://www.revive-adserver.com</authorUrl>
     <license>GNU Gneral Public License v2</license>
     <description>Plugin that provides IAB VAST video ad support.</description>
-    <version>1.10.8</version>
+    <version>1.10.9</version>
     <oxversion>3.1-dev</oxversion>
     <extends>bannerTypeHtml</extends>
 

--- a/plugins_repo/openXVideoAds/plugins/etc/vastServeVideoPlayer/vastServeVideoPlayer.xml
+++ b/plugins_repo/openXVideoAds/plugins/etc/vastServeVideoPlayer/vastServeVideoPlayer.xml
@@ -3,13 +3,13 @@
 <plugin>
     <name>vastServeVideoPlayer</name>
     <displayName>IAB VAST Video Player Plugin</displayName>
-    <creationDate>2014-11-21</creationDate>
+    <creationDate>2015-01-23</creationDate>
     <author>Revive Adserver</author>
     <authorEmail>revive@revive-adserver.com</authorEmail>
     <authorUrl>http://www.revive-adserver.com</authorUrl>
     <license>GNU Gneral Public License v2</license>
     <description>Plugin that provides IAB VAST video ad support.</description>
-    <version>1.10.8</version>
+    <version>1.10.9</version>
     <oxversion>2.7.30-beta-rc11</oxversion>
 
     <install>

--- a/plugins_repo/openXVideoAds/plugins/etc/videoReport/videoReport.xml
+++ b/plugins_repo/openXVideoAds/plugins/etc/videoReport/videoReport.xml
@@ -4,13 +4,13 @@
 <plugin>
     <name>videoReport</name>
     <displayName>IAB VAST Report Plugin</displayName>
-    <creationDate>2014-11-21</creationDate>
+    <creationDate>2015-01-23</creationDate>
     <author>Revive Adserver</author>
     <authorEmail>revive@revive-adserver.com</authorEmail>
     <authorUrl>http://www.revive-adserver.com</authorUrl>
     <license>GNU Gneral Public License v2</license>
     <description>Plugin that provides IAB VAST video ad support.</description>
-    <version>1.10.8</version>
+    <version>1.10.9</version>
     <oxversion>2.7.30-beta-rc11</oxversion>
 
     <install>


### PR DESCRIPTION
Crossdomain example was pointing to OpenX SVN and documentation examples to OpenX articles. Inline Video banners doc is missing but at least points to revive empty doc entry