### PR TITLE
Add remote ip to details array when registering events in the Audit table

### DIFF
--- a/lib/max/Dal/DataObjects/DB_DataObjectCommon.php
+++ b/lib/max/Dal/DataObjects/DB_DataObjectCommon.php
@@ -1570,6 +1570,10 @@ class DB_DataObjectCommon extends DB_DataObject
                 $this->_buildAuditArray($actionid, $aAuditFields);
                 // Do not audit if nothing has changed
                 if (count($aAuditFields)) {
+                    //Add the remote address to the details array in order to show it on userlog-audit-detailed
+                    if(!empty($_SERVER['REMOTE_ADDR'])){
+                        $aAuditFields['ip'] = $_SERVER['REMOTE_ADDR'];
+                    }
                     // Serialise the data
                     $this->doAudit->details = serialize($aAuditFields);
                     $this->doAudit->updated = OA::getNowUTC();


### PR DESCRIPTION
Following this discussion
https://github.com/revive-adserver/revive-adserver/issues/474
I added the remote ip to the details array, it is automatically shown
on userlog-audit-detailed page
