### PR TITLE
Force to a limit, to avoid unlimited query at the first time.

### DIFF
--- a/lib/OA/Dll/Audit.php
+++ b/lib/OA/Dll/Audit.php
@@ -261,6 +261,8 @@ class OA_Dll_Audit extends OA_Dll
 
             if ((!empty($aParam['startRecord']) || $aParam['startRecord'] >= 0) && $aParam['perPage']) {
                 $doAudit->limit($aParam['startRecord'], $aParam['perPage']);
+            }else{
+                $doAudit->limit(0,500); //force to a limit, to avoid unlimited querie
             }
 
             $numRows = $doAudit->find();


### PR DESCRIPTION
For more details, please see issue >> Exceeded the Maximum execution time for "User Log" #518