### PR TITLE
Added a checking for to know if banner has any restrictions before call ...

### DIFF
--- a/www/api/v2/xmlrpc/BannerXmlRpcService.php
+++ b/www/api/v2/xmlrpc/BannerXmlRpcService.php
@@ -167,9 +167,14 @@ class BannerXmlRpcService extends BaseBannerService
         $aTargeting = null;
         if ($this->_oBannerServiceImp->getBannerTargeting($sessionId,
             $bannerId, $aTargeting)) {
-
-            return XmlRpcUtils::getArrayOfEntityResponse($aTargeting);
-
+            if ($aTargeting) {                
+                
+                return XmlRpcUtils::getArrayOfEntityResponse($aTargeting);
+            } else {                
+                $value = new XML_RPC_Value(array(), $GLOBALS['XML_RPC_Array']);
+                
+                return new XML_RPC_Response($value);
+            }
         } else {
 
             return XmlRpcUtils::generateError($this->_oBannerServiceImp->getLastError());


### PR DESCRIPTION
...getArrayOfEntityResponse.

I was having a problem to use getBannerTargeting() for a banner without any delivery limitations. 
A warning was showing :

XmlRpcFrontController->getBannerTargeting:Invalid argument supplied for foreach()

So, my solution was to add a checking for $targeting before return the XML_RPC_Response.