### PR TITLE
numberFormat.js.php includes default.lang.php without some GLOBALS

### DIFF
--- a/www/admin/numberFormat.js.php
+++ b/www/admin/numberFormat.js.php
@@ -40,6 +40,9 @@ include('../../constants.php');
 $GLOBALS['_MAX']['CONF'] = true;
 setupConstants();
 
+$PRODUCT_NAME = PRODUCT_NAME;
+$PRODUCT_DOCSURL = PRODUCT_DOCSURL;
+
 //Always load the English language, in case of incomplete translations
 include '../../lib/max/language/en/default.lang.php';
 


### PR DESCRIPTION
numberFormat.js.php requires 'lib/max/language/en/default.lang.php' without setup two globals PRODUCT_NAME and PRODUCT_DOCSURL. This usually happens in lib/max/language/Loader.php, but numberFormat.js.php seem not to require a login.

I assume a better fix would be to do a normal "init.php" ... but maybe this do it for now.