### PR TITLE
Async ads for IE9 using XDomainRequest

### DIFF
--- a/www/delivery_dev/async.js
+++ b/www/delivery_dev/async.js
@@ -39,19 +39,35 @@
                  * @param object data
                  */
                 ajax: function (url, data) {
-                    var xhr = new XMLHttpRequest();
+                    if ($.browser.msie && window.XDomainRequest) {
+                        var emptyFunction = function(){ return; },
+                            xdr = new XDomainRequest();
 
-                    xhr.onreadystatechange = function() {
-                        if (this.readyState == 4 ) {
-                            if (this.status == 200) {
-                                rv.spc(JSON.parse(this.responseText));
+                        xdr.onerror = emptyFunction;
+                        xdr.ontimeout = emptyFunction;
+                        xdr.onprogress = emptyFunction;
+                        xdr.onload = function () {
+                            rv.spc(JSON.parse(this.responseText));
+                        };
+                        xdr.timeout = 5000;
+
+                        xdr.open("GET", e + "?" + f.encode(g).join("&"), true);
+                        xdr.send(null);
+                    } else {
+                        var xhr = new XMLHttpRequest();
+
+                        xhr.onreadystatechange = function () {
+                            if (this.readyState == 4) {
+                                if (this.status == 200) {
+                                    rv.spc(JSON.parse(this.responseText));
+                                }
                             }
-                        }
-                    };
+                        };
 
-                    xhr.open("GET", url + "?" + rv.encode(data).join("&"), true);
-                    xhr.withCredentials = true;
-                    xhr.send();
+                        xhr.open("GET", url + "?" + rv.encode(data).join("&"), true);
+                        xhr.withCredentials = true;
+                        xhr.send();
+                    }
                 },
 
                 /**


### PR DESCRIPTION
This is my first pull request to this project so please let me know if this is the right way of proposing changes.

--------------------

Hi guys,

We have implemented Asynchronous ads in our site recently and they worked well with the exception of IE9 that couldn't make Ajax calls the the ad server, which is located in a different subdomain than the website.

We found a couple of links that helped us fixing the issue:

* http://stackoverflow.com/questions/5087549/access-denied-to-jquery-script-on-ie
* http://stackoverflow.com/questions/5250256/inconsistent-ajax-xdr-response-from-ie

We have implemented this change in our production environment and it is working well on IE9. 

Please let me know if I can help you further with it and I hope you find this useful.

Cheers,
Ignacio
