### PR TITLE
adRender: Fix wrong number of arguments when rendering image inside f…

### DIFF
--- a/lib/max/Delivery/adRender.php
+++ b/lib/max/Delivery/adRender.php
@@ -300,7 +300,7 @@ function _adRenderFlash(&$aBanner, $zoneId=0, $source='', $ct0='', $withText=fal
     $logURL = _adRenderBuildLogURL($aBanner, $zoneId, $source, $loc, $referer, '&');
 
     if (!empty($aBanner['alt_filename']) || !empty($aBanner['alt_imageurl'])) {
-        $altImageAdCode = _adRenderImage($aBanner, $zoneId, $source, $ct0, false, $logClick, false, true, true, $loc, $referer, false);
+        $altImageAdCode = _adRenderImage($aBanner, $zoneId, $source, $ct0, false, $logClick, false, true, true, $loc, $referer, $context, false);
         $fallBackLogURL = _adRenderBuildLogURL($aBanner, $zoneId, $source, $loc, $referer, '&', true);
     } else {
         $alt = !empty($aBanner['alt']) ? htmlspecialchars($aBanner['alt'], ENT_QUOTES) : '';


### PR DESCRIPTION
…lash banner

BUG: `append` HTML is rendered twice when you have flash banner with image fallback. Once for image HTML and once for flash HTML.

This PR should fix wrong arguments passing when rendering image inside flash banner. 