### PR TITLE
Fix contract translation in spanish

### DIFF
--- a/plugins_repo/openXReports/plugins/etc/oxReportsStandard/_lang/po/es.po
+++ b/plugins_repo/openXReports/plugins/etc/oxReportsStandard/_lang/po/es.po
@@ -121,7 +121,7 @@ msgstr ""
 
 #: plugins_repo/openXReports/extensions/reports/oxReportsStandard//liveCampaignDeliveryReport.class.php:526
 msgid "Contract"
-msgstr "Contacto"
+msgstr "Contrato"
 
 #: plugins_repo/openXReports/extensions/reports/oxReportsStandard//advertisingAnalysisReport.class.php:93
 msgid "Advertising Analysis Report"


### PR DESCRIPTION
Contract was translated as "Contacto" when it should be "Contrato"