### PR TITLE
Fix #680 PHP7 infinity loop in statistics

### DIFF
--- a/lib/pear/Date/Span.php
+++ b/lib/pear/Date/Span.php
@@ -340,7 +340,7 @@ class Date_Span {
                 if (is_null($val)) {
                     return false;
                 }
-                $$vars[$i] = $val;
+                ${$vars[$i]} = $val;
             }
             if (strcasecmp($pm, 'pm') == 0) {
                 $hour += 12;


### PR DESCRIPTION
Wrong filling properties in Date_Span::setFromString
See http://php.net/manual/en/migration70.incompatible.php#migration70.incompatible.variable-handling.indirect