### PR TITLE
Make .htaccess files compatible for apache >= 2.4

### DIFF
--- a/etc/.htaccess
+++ b/etc/.htaccess
@@ -1,2 +1,11 @@
 # Deny all users web access to this directory
-Deny from all
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Deny from all
+</IfModule>

--- a/lib/.htaccess
+++ b/lib/.htaccess
@@ -1,2 +1,11 @@
 # Deny all users web access to this directory
-Deny from all
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Deny from all
+</IfModule>

--- a/plugins/.htaccess
+++ b/plugins/.htaccess
@@ -1,2 +1,11 @@
 # Deny all users web access to this directory
-Deny from all
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Deny from all
+</IfModule>

--- a/scripts/.htaccess
+++ b/scripts/.htaccess
@@ -1,2 +1,11 @@
 # Deny all users web access to this directory
-Deny from all
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Deny from all
+</IfModule>

--- a/tutorials/.htaccess
+++ b/tutorials/.htaccess
@@ -1,2 +1,11 @@
 # Deny all users web access to this directory
-Deny from all
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Deny from all
+</IfModule>

--- a/var/.htaccess
+++ b/var/.htaccess
@@ -1,2 +1,11 @@
 # Deny all users web access to this directory
-Deny from all
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Deny from all
+</IfModule>


### PR DESCRIPTION
The actual rules in the .htaccess files are not working with apache 2.4 and above.

For more information see http://httpd.apache.org/docs/2.4/upgrading.html#authz.