### PR TITLE
Allow ability to add custom querystring variables to the ad call, and have these variables pass through to the click and log calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@
 /www/images/
 /plugins_repo/build-ap.xml
 /plugins_repo/release/*.zip
+.idea/
+*.iml

--- a/etc/dist.conf.php
+++ b/etc/dist.conf.php
@@ -334,6 +334,7 @@ disableSendEmails   = false                 ; If true, no email will be sent fro
 
 [var]
 prefix              = OA_           ; Used to prefix some variables and used in invocation codes
+customVars          =               ; Comma list of additional variables to pass to the click and log URLs from the AdJS/AdFrame/etc URL querystrings
 cookieTest          = ct            ; Used for the forced cookie test redirect
 cacheBuster         = cb            ; Cache buster
 channel             = source        ; Channel of the website

--- a/lib/max/Delivery/adRender.php
+++ b/lib/max/Delivery/adRender.php
@@ -559,8 +559,12 @@ function _adRenderBuildLogURL($aBanner, $zoneId = 0, $source = '', $loc = '', $r
     }
 
     // JSS - hack here for the following reason: There is no way to use the adUrlParams hook to add foo={foo}, since the param values are url encoded
-    $url .= $amp . "auction_id={auction_id}";
-    $url .= $amp . "winprice={winprice}";
+    if (!empty($conf['var']['customVars'])) {
+        $customVars = explode(',',$conf['var']['customVars']);
+        foreach ($customVars as $customVar) {
+            $url .= "{$amp}{$customVar}={{$customVar}}";
+        }
+    }
 
     return $url;
 }
@@ -660,9 +664,12 @@ function _adRenderBuildParams($aBanner, $zoneId=0, $source='', $ct0='', $logClic
         }
 
         // JSS - hack here for the following reason: There is no way to use the adUrlParams hook to add foo={foo}, since the param values are url encoded
-        $auction_id = "{$del}auction_id={auction_id}";
-        $winprice = "{$del}winprice={winprice}";
-        $maxparams .= $auction_id . $winprice;
+        if (!empty($conf['var']['customVars'])) {
+            $customVars = explode(',',$conf['var']['customVars']);
+            foreach ($customVars as $customVar) {
+                $maxparams .= "{$del}{$customVar}={{$customVar}}";
+            }
+        }
 
         $maxparams .= $maxdest;
     }

--- a/lib/max/Delivery/adRender.php
+++ b/lib/max/Delivery/adRender.php
@@ -557,6 +557,11 @@ function _adRenderBuildLogURL($aBanner, $zoneId = 0, $source = '', $loc = '', $r
             }
         }
     }
+
+    // JSS - hack here for the following reason: There is no way to use the adUrlParams hook to add foo={foo}, since the param values are url encoded
+    $url .= $amp . "auction_id={auction_id}";
+    $url .= $amp . "winprice={winprice}";
+
     return $url;
 }
 
@@ -641,6 +646,7 @@ function _adRenderBuildParams($aBanner, $zoneId=0, $source='', $ct0='', $logClic
         $log .= (!empty($logLastClick)) ? $del . $conf['var']['lastClick'] . '=' . $logLastClick : '';
 
         $maxparams = $delnum . $bannerId . $zoneId . $source . $log . $random;
+
         // addUrlParams hook for plugins to add key=value pairs to the log/click URLs
         $componentParams =  OX_Delivery_Common_hook('addUrlParams', array($aBanner));
         if (!empty($componentParams) && is_array($componentParams)) {
@@ -652,6 +658,12 @@ function _adRenderBuildParams($aBanner, $zoneId=0, $source='', $ct0='', $logClic
                 }
             }
         }
+
+        // JSS - hack here for the following reason: There is no way to use the adUrlParams hook to add foo={foo}, since the param values are url encoded
+        $auction_id = "{$del}auction_id={auction_id}";
+        $winprice = "{$del}winprice={winprice}";
+        $maxparams .= $auction_id . $winprice;
+
         $maxparams .= $maxdest;
     }
     return $maxparams;

--- a/www/delivery/ac.php
+++ b/www/delivery/ac.php
@@ -3480,6 +3480,8 @@ $url .= $amp . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
+$url .= $amp . "auction_id={auction_id}";
+$url .= $amp . "winprice={winprice}";
 return $url;
 }
 function _adRenderImageBeacon($aBanner, $zoneId = 0, $source = '', $loc = '', $referer = '', $logUrl = '')

--- a/www/delivery/ac.php
+++ b/www/delivery/ac.php
@@ -3480,8 +3480,12 @@ $url .= $amp . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
-$url .= $amp . "auction_id={auction_id}";
-$url .= $amp . "winprice={winprice}";
+if (!empty($conf['var']['customVars'])) {
+$customVars = explode(',',$conf['var']['customVars']);
+foreach ($customVars as $customVar) {
+$url .= "{$amp}{$customVar}={{$customVar}}";
+}
+}
 return $url;
 }
 function _adRenderImageBeacon($aBanner, $zoneId = 0, $source = '', $loc = '', $referer = '', $logUrl = '')

--- a/www/delivery/afr.php
+++ b/www/delivery/afr.php
@@ -3480,6 +3480,8 @@ $url .= $amp . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
+$url .= $amp . "auction_id={auction_id}";
+$url .= $amp . "winprice={winprice}";
 return $url;
 }
 function _adRenderImageBeacon($aBanner, $zoneId = 0, $source = '', $loc = '', $referer = '', $logUrl = '')
@@ -3532,6 +3534,9 @@ $maxparams .= $del . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
+$auction_id = "{$del}auction_id={auction_id}";
+$winprice = "{$del}winprice={winprice}";
+$maxparams .= $auction_id . $winprice;
 $maxparams .= $maxdest;
 }
 return $maxparams;

--- a/www/delivery/afr.php
+++ b/www/delivery/afr.php
@@ -3480,8 +3480,12 @@ $url .= $amp . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
-$url .= $amp . "auction_id={auction_id}";
-$url .= $amp . "winprice={winprice}";
+if (!empty($conf['var']['customVars'])) {
+$customVars = explode(',',$conf['var']['customVars']);
+foreach ($customVars as $customVar) {
+$url .= "{$amp}{$customVar}={{$customVar}}";
+}
+}
 return $url;
 }
 function _adRenderImageBeacon($aBanner, $zoneId = 0, $source = '', $loc = '', $referer = '', $logUrl = '')
@@ -3534,9 +3538,12 @@ $maxparams .= $del . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
-$auction_id = "{$del}auction_id={auction_id}";
-$winprice = "{$del}winprice={winprice}";
-$maxparams .= $auction_id . $winprice;
+if (!empty($conf['var']['customVars'])) {
+$customVars = explode(',',$conf['var']['customVars']);
+foreach ($customVars as $customVar) {
+$maxparams .= "{$del}{$customVar}={{$customVar}}";
+}
+}
 $maxparams .= $maxdest;
 }
 return $maxparams;

--- a/www/delivery/ajs.php
+++ b/www/delivery/ajs.php
@@ -3480,6 +3480,8 @@ $url .= $amp . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
+$url .= $amp . "auction_id={auction_id}";
+$url .= $amp . "winprice={winprice}";
 return $url;
 }
 function _adRenderImageBeacon($aBanner, $zoneId = 0, $source = '', $loc = '', $referer = '', $logUrl = '')
@@ -3532,6 +3534,9 @@ $maxparams .= $del . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
+$auction_id = "{$del}auction_id={auction_id}";
+$winprice = "{$del}winprice={winprice}";
+$maxparams .= $auction_id . $winprice;
 $maxparams .= $maxdest;
 }
 return $maxparams;

--- a/www/delivery/ajs.php
+++ b/www/delivery/ajs.php
@@ -3480,8 +3480,12 @@ $url .= $amp . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
-$url .= $amp . "auction_id={auction_id}";
-$url .= $amp . "winprice={winprice}";
+if (!empty($conf['var']['customVars'])) {
+$customVars = explode(',',$conf['var']['customVars']);
+foreach ($customVars as $customVar) {
+$url .= "{$amp}{$customVar}={{$customVar}}";
+}
+}
 return $url;
 }
 function _adRenderImageBeacon($aBanner, $zoneId = 0, $source = '', $loc = '', $referer = '', $logUrl = '')
@@ -3534,9 +3538,12 @@ $maxparams .= $del . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
-$auction_id = "{$del}auction_id={auction_id}";
-$winprice = "{$del}winprice={winprice}";
-$maxparams .= $auction_id . $winprice;
+if (!empty($conf['var']['customVars'])) {
+$customVars = explode(',',$conf['var']['customVars']);
+foreach ($customVars as $customVar) {
+$maxparams .= "{$del}{$customVar}={{$customVar}}";
+}
+}
 $maxparams .= $maxdest;
 }
 return $maxparams;

--- a/www/delivery/al.php
+++ b/www/delivery/al.php
@@ -3480,6 +3480,8 @@ $url .= $amp . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
+$url .= $amp . "auction_id={auction_id}";
+$url .= $amp . "winprice={winprice}";
 return $url;
 }
 function _adRenderImageBeacon($aBanner, $zoneId = 0, $source = '', $loc = '', $referer = '', $logUrl = '')
@@ -3532,6 +3534,9 @@ $maxparams .= $del . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
+$auction_id = "{$del}auction_id={auction_id}";
+$winprice = "{$del}winprice={winprice}";
+$maxparams .= $auction_id . $winprice;
 $maxparams .= $maxdest;
 }
 return $maxparams;

--- a/www/delivery/al.php
+++ b/www/delivery/al.php
@@ -3480,8 +3480,12 @@ $url .= $amp . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
-$url .= $amp . "auction_id={auction_id}";
-$url .= $amp . "winprice={winprice}";
+if (!empty($conf['var']['customVars'])) {
+$customVars = explode(',',$conf['var']['customVars']);
+foreach ($customVars as $customVar) {
+$url .= "{$amp}{$customVar}={{$customVar}}";
+}
+}
 return $url;
 }
 function _adRenderImageBeacon($aBanner, $zoneId = 0, $source = '', $loc = '', $referer = '', $logUrl = '')
@@ -3534,9 +3538,12 @@ $maxparams .= $del . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
-$auction_id = "{$del}auction_id={auction_id}";
-$winprice = "{$del}winprice={winprice}";
-$maxparams .= $auction_id . $winprice;
+if (!empty($conf['var']['customVars'])) {
+$customVars = explode(',',$conf['var']['customVars']);
+foreach ($customVars as $customVar) {
+$maxparams .= "{$del}{$customVar}={{$customVar}}";
+}
+}
 $maxparams .= $maxdest;
 }
 return $maxparams;

--- a/www/delivery/alocal.php
+++ b/www/delivery/alocal.php
@@ -3480,6 +3480,8 @@ $url .= $amp . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
+$url .= $amp . "auction_id={auction_id}";
+$url .= $amp . "winprice={winprice}";
 return $url;
 }
 function _adRenderImageBeacon($aBanner, $zoneId = 0, $source = '', $loc = '', $referer = '', $logUrl = '')
@@ -3532,6 +3534,9 @@ $maxparams .= $del . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
+$auction_id = "{$del}auction_id={auction_id}";
+$winprice = "{$del}winprice={winprice}";
+$maxparams .= $auction_id . $winprice;
 $maxparams .= $maxdest;
 }
 return $maxparams;

--- a/www/delivery/alocal.php
+++ b/www/delivery/alocal.php
@@ -3480,8 +3480,12 @@ $url .= $amp . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
-$url .= $amp . "auction_id={auction_id}";
-$url .= $amp . "winprice={winprice}";
+if (!empty($conf['var']['customVars'])) {
+$customVars = explode(',',$conf['var']['customVars']);
+foreach ($customVars as $customVar) {
+$url .= "{$amp}{$customVar}={{$customVar}}";
+}
+}
 return $url;
 }
 function _adRenderImageBeacon($aBanner, $zoneId = 0, $source = '', $loc = '', $referer = '', $logUrl = '')
@@ -3534,9 +3538,12 @@ $maxparams .= $del . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
-$auction_id = "{$del}auction_id={auction_id}";
-$winprice = "{$del}winprice={winprice}";
-$maxparams .= $auction_id . $winprice;
+if (!empty($conf['var']['customVars'])) {
+$customVars = explode(',',$conf['var']['customVars']);
+foreach ($customVars as $customVar) {
+$maxparams .= "{$del}{$customVar}={{$customVar}}";
+}
+}
 $maxparams .= $maxdest;
 }
 return $maxparams;

--- a/www/delivery/apu.php
+++ b/www/delivery/apu.php
@@ -3480,6 +3480,8 @@ $url .= $amp . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
+$url .= $amp . "auction_id={auction_id}";
+$url .= $amp . "winprice={winprice}";
 return $url;
 }
 function _adRenderImageBeacon($aBanner, $zoneId = 0, $source = '', $loc = '', $referer = '', $logUrl = '')
@@ -3532,6 +3534,9 @@ $maxparams .= $del . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
+$auction_id = "{$del}auction_id={auction_id}";
+$winprice = "{$del}winprice={winprice}";
+$maxparams .= $auction_id . $winprice;
 $maxparams .= $maxdest;
 }
 return $maxparams;

--- a/www/delivery/apu.php
+++ b/www/delivery/apu.php
@@ -3480,8 +3480,12 @@ $url .= $amp . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
-$url .= $amp . "auction_id={auction_id}";
-$url .= $amp . "winprice={winprice}";
+if (!empty($conf['var']['customVars'])) {
+$customVars = explode(',',$conf['var']['customVars']);
+foreach ($customVars as $customVar) {
+$url .= "{$amp}{$customVar}={{$customVar}}";
+}
+}
 return $url;
 }
 function _adRenderImageBeacon($aBanner, $zoneId = 0, $source = '', $loc = '', $referer = '', $logUrl = '')
@@ -3534,9 +3538,12 @@ $maxparams .= $del . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
-$auction_id = "{$del}auction_id={auction_id}";
-$winprice = "{$del}winprice={winprice}";
-$maxparams .= $auction_id . $winprice;
+if (!empty($conf['var']['customVars'])) {
+$customVars = explode(',',$conf['var']['customVars']);
+foreach ($customVars as $customVar) {
+$maxparams .= "{$del}{$customVar}={{$customVar}}";
+}
+}
 $maxparams .= $maxdest;
 }
 return $maxparams;

--- a/www/delivery/asyncspc.php
+++ b/www/delivery/asyncspc.php
@@ -3480,6 +3480,8 @@ $url .= $amp . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
+$url .= $amp . "auction_id={auction_id}";
+$url .= $amp . "winprice={winprice}";
 return $url;
 }
 function _adRenderImageBeacon($aBanner, $zoneId = 0, $source = '', $loc = '', $referer = '', $logUrl = '')
@@ -3532,6 +3534,9 @@ $maxparams .= $del . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
+$auction_id = "{$del}auction_id={auction_id}";
+$winprice = "{$del}winprice={winprice}";
+$maxparams .= $auction_id . $winprice;
 $maxparams .= $maxdest;
 }
 return $maxparams;

--- a/www/delivery/asyncspc.php
+++ b/www/delivery/asyncspc.php
@@ -3480,8 +3480,12 @@ $url .= $amp . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
-$url .= $amp . "auction_id={auction_id}";
-$url .= $amp . "winprice={winprice}";
+if (!empty($conf['var']['customVars'])) {
+$customVars = explode(',',$conf['var']['customVars']);
+foreach ($customVars as $customVar) {
+$url .= "{$amp}{$customVar}={{$customVar}}";
+}
+}
 return $url;
 }
 function _adRenderImageBeacon($aBanner, $zoneId = 0, $source = '', $loc = '', $referer = '', $logUrl = '')
@@ -3534,9 +3538,12 @@ $maxparams .= $del . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
-$auction_id = "{$del}auction_id={auction_id}";
-$winprice = "{$del}winprice={winprice}";
-$maxparams .= $auction_id . $winprice;
+if (!empty($conf['var']['customVars'])) {
+$customVars = explode(',',$conf['var']['customVars']);
+foreach ($customVars as $customVar) {
+$maxparams .= "{$del}{$customVar}={{$customVar}}";
+}
+}
 $maxparams .= $maxdest;
 }
 return $maxparams;

--- a/www/delivery/avw.php
+++ b/www/delivery/avw.php
@@ -3480,6 +3480,8 @@ $url .= $amp . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
+$url .= $amp . "auction_id={auction_id}";
+$url .= $amp . "winprice={winprice}";
 return $url;
 }
 function _adRenderImageBeacon($aBanner, $zoneId = 0, $source = '', $loc = '', $referer = '', $logUrl = '')
@@ -3532,6 +3534,9 @@ $maxparams .= $del . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
+$auction_id = "{$del}auction_id={auction_id}";
+$winprice = "{$del}winprice={winprice}";
+$maxparams .= $auction_id . $winprice;
 $maxparams .= $maxdest;
 }
 return $maxparams;

--- a/www/delivery/avw.php
+++ b/www/delivery/avw.php
@@ -3480,8 +3480,12 @@ $url .= $amp . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
-$url .= $amp . "auction_id={auction_id}";
-$url .= $amp . "winprice={winprice}";
+if (!empty($conf['var']['customVars'])) {
+$customVars = explode(',',$conf['var']['customVars']);
+foreach ($customVars as $customVar) {
+$url .= "{$amp}{$customVar}={{$customVar}}";
+}
+}
 return $url;
 }
 function _adRenderImageBeacon($aBanner, $zoneId = 0, $source = '', $loc = '', $referer = '', $logUrl = '')
@@ -3534,9 +3538,12 @@ $maxparams .= $del . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
-$auction_id = "{$del}auction_id={auction_id}";
-$winprice = "{$del}winprice={winprice}";
-$maxparams .= $auction_id . $winprice;
+if (!empty($conf['var']['customVars'])) {
+$customVars = explode(',',$conf['var']['customVars']);
+foreach ($customVars as $customVar) {
+$maxparams .= "{$del}{$customVar}={{$customVar}}";
+}
+}
 $maxparams .= $maxdest;
 }
 return $maxparams;

--- a/www/delivery/ax.php
+++ b/www/delivery/ax.php
@@ -3480,6 +3480,8 @@ $url .= $amp . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
+$url .= $amp . "auction_id={auction_id}";
+$url .= $amp . "winprice={winprice}";
 return $url;
 }
 function _adRenderImageBeacon($aBanner, $zoneId = 0, $source = '', $loc = '', $referer = '', $logUrl = '')
@@ -3532,6 +3534,9 @@ $maxparams .= $del . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
+$auction_id = "{$del}auction_id={auction_id}";
+$winprice = "{$del}winprice={winprice}";
+$maxparams .= $auction_id . $winprice;
 $maxparams .= $maxdest;
 }
 return $maxparams;

--- a/www/delivery/ax.php
+++ b/www/delivery/ax.php
@@ -3480,8 +3480,12 @@ $url .= $amp . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
-$url .= $amp . "auction_id={auction_id}";
-$url .= $amp . "winprice={winprice}";
+if (!empty($conf['var']['customVars'])) {
+$customVars = explode(',',$conf['var']['customVars']);
+foreach ($customVars as $customVar) {
+$url .= "{$amp}{$customVar}={{$customVar}}";
+}
+}
 return $url;
 }
 function _adRenderImageBeacon($aBanner, $zoneId = 0, $source = '', $loc = '', $referer = '', $logUrl = '')
@@ -3534,9 +3538,12 @@ $maxparams .= $del . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
-$auction_id = "{$del}auction_id={auction_id}";
-$winprice = "{$del}winprice={winprice}";
-$maxparams .= $auction_id . $winprice;
+if (!empty($conf['var']['customVars'])) {
+$customVars = explode(',',$conf['var']['customVars']);
+foreach ($customVars as $customVar) {
+$maxparams .= "{$del}{$customVar}={{$customVar}}";
+}
+}
 $maxparams .= $maxdest;
 }
 return $maxparams;

--- a/www/delivery/axmlrpc.php
+++ b/www/delivery/axmlrpc.php
@@ -3617,6 +3617,8 @@ $url .= $amp . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
+$url .= $amp . "auction_id={auction_id}";
+$url .= $amp . "winprice={winprice}";
 return $url;
 }
 function _adRenderImageBeacon($aBanner, $zoneId = 0, $source = '', $loc = '', $referer = '', $logUrl = '')
@@ -3669,6 +3671,9 @@ $maxparams .= $del . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
+$auction_id = "{$del}auction_id={auction_id}";
+$winprice = "{$del}winprice={winprice}";
+$maxparams .= $auction_id . $winprice;
 $maxparams .= $maxdest;
 }
 return $maxparams;

--- a/www/delivery/axmlrpc.php
+++ b/www/delivery/axmlrpc.php
@@ -3617,8 +3617,12 @@ $url .= $amp . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
-$url .= $amp . "auction_id={auction_id}";
-$url .= $amp . "winprice={winprice}";
+if (!empty($conf['var']['customVars'])) {
+$customVars = explode(',',$conf['var']['customVars']);
+foreach ($customVars as $customVar) {
+$url .= "{$amp}{$customVar}={{$customVar}}";
+}
+}
 return $url;
 }
 function _adRenderImageBeacon($aBanner, $zoneId = 0, $source = '', $loc = '', $referer = '', $logUrl = '')
@@ -3671,9 +3675,12 @@ $maxparams .= $del . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
-$auction_id = "{$del}auction_id={auction_id}";
-$winprice = "{$del}winprice={winprice}";
-$maxparams .= $auction_id . $winprice;
+if (!empty($conf['var']['customVars'])) {
+$customVars = explode(',',$conf['var']['customVars']);
+foreach ($customVars as $customVar) {
+$maxparams .= "{$del}{$customVar}={{$customVar}}";
+}
+}
 $maxparams .= $maxdest;
 }
 return $maxparams;

--- a/www/delivery/spc.php
+++ b/www/delivery/spc.php
@@ -3480,6 +3480,8 @@ $url .= $amp . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
+$url .= $amp . "auction_id={auction_id}";
+$url .= $amp . "winprice={winprice}";
 return $url;
 }
 function _adRenderImageBeacon($aBanner, $zoneId = 0, $source = '', $loc = '', $referer = '', $logUrl = '')
@@ -3532,6 +3534,9 @@ $maxparams .= $del . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
+$auction_id = "{$del}auction_id={auction_id}";
+$winprice = "{$del}winprice={winprice}";
+$maxparams .= $auction_id . $winprice;
 $maxparams .= $maxdest;
 }
 return $maxparams;

--- a/www/delivery/spc.php
+++ b/www/delivery/spc.php
@@ -3480,8 +3480,12 @@ $url .= $amp . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
-$url .= $amp . "auction_id={auction_id}";
-$url .= $amp . "winprice={winprice}";
+if (!empty($conf['var']['customVars'])) {
+$customVars = explode(',',$conf['var']['customVars']);
+foreach ($customVars as $customVar) {
+$url .= "{$amp}{$customVar}={{$customVar}}";
+}
+}
 return $url;
 }
 function _adRenderImageBeacon($aBanner, $zoneId = 0, $source = '', $loc = '', $referer = '', $logUrl = '')
@@ -3534,9 +3538,12 @@ $maxparams .= $del . urlencode($key) . '=' . urlencode($value);
 }
 }
 }
-$auction_id = "{$del}auction_id={auction_id}";
-$winprice = "{$del}winprice={winprice}";
-$maxparams .= $auction_id . $winprice;
+if (!empty($conf['var']['customVars'])) {
+$customVars = explode(',',$conf['var']['customVars']);
+foreach ($customVars as $customVar) {
+$maxparams .= "{$del}{$customVar}={{$customVar}}";
+}
+}
 $maxparams .= $maxdest;
 }
 return $maxparams;


### PR DESCRIPTION
Hi - this pull request is referencing this forum thread:

http://forum.revive-adserver.com/topic/3674-adding-querystring-variables-from-adjsadframe-to-flow-through-to-click-and-log-urls/

Ultimately, this should be a plugin, but because the values are URL encoded, you cannot build a plugin that needs to pull a querystring variable.
