### PR TITLE
Support {clickurl} for DoubleClick on https

### DIFF
--- a/plugins_repo/openX3rdPartyServers/plugins/3rdPartyServers/ox3rdPartyServers/doubleclick.class.php
+++ b/plugins_repo/openX3rdPartyServers/plugins/3rdPartyServers/ox3rdPartyServers/doubleclick.class.php
@@ -46,8 +46,8 @@ class Plugins_3rdPartyServers_ox3rdPartyServers_doubleclick extends Plugins_3rdP
      */
     function getBannerCache($buffer, &$noScript)
     {
-        $search  = array("/\[timestamp\]/i", "/(http:.*?;)(.*?)/i");
-        $replace = array("{random}",      "$1click0={clickurl};$2");
+        $search  = array("/\[timestamp\]/i", "/(http:.*?;)(.*?)/i", "/(https:.*?;)(.*?)/i");
+        $replace = array("{random}",      "$1click0={clickurl};$2", "$1click0={clickurl};$2");
 
         $buffer = preg_replace ($search, $replace, $buffer);
         $noScript[0] = preg_replace($search[0], $replace[0], $noScript[0]);


### PR DESCRIPTION
DoubleClick plugin could not inject {clickurl} into https URLs.

Fixes https://github.com/revive-adserver/revive-adserver/issues/735