### PR TITLE
Migrating oxMemcached to use memcached instead of memcache

### DIFF
--- a/plugins_repo/openXDeliveryCacheStore/plugins/deliveryCacheStore/oxMemcached/oxMemcached.class.php
+++ b/plugins_repo/openXDeliveryCacheStore/plugins/deliveryCacheStore/oxMemcached/oxMemcached.class.php
@@ -44,36 +44,30 @@ class Plugins_DeliveryCacheStore_oxMemcached_oxMemcached extends Plugins_Deliver
         $aConf = $GLOBALS['_MAX']['CONF'];
 
         // Check if memcached is enabled in php.ini
-        if (!class_exists('Memcached') && !class_exists('Memcache'))
-        {
+        if (!class_exists('Memcached') && !class_exists('Memcache')) {
             return array($this->translate('strNoMemcacheModuleInPhp'));
         }
         // Check servers list
         $aServers = (explode(',', $aConf[$this->group]['memcachedServers']));
-        if (count($aServers) > 0)
-        {
-            foreach ($aServers as $key => $server)
-            {
+        if (count($aServers) > 0) {
+            foreach ($aServers as $key => $server) {
                 if (empty($server)) {
                     unset($aServers[$key]);
                 }
             }
         }
-        if (count($aServers) == 0)
-        {
+        if (count($aServers) == 0) {
             return $this->translate('strEmptyServerList', array('plugin-settings.php?group=oxMemcached'));
         }
 
-        if(class_exists('Memcached')){
+        if (class_exists('Memcached')) {
             $oMemcache = new Memcached();
         } else {
             $oMemcache = new Memcache();
         }
 
-        foreach ($aServers as $server)
-        {
-            if (!_oxMemcached_addMemcachedServer($oMemcache, $server))
-            {
+        foreach ($aServers as $server) {
+            if (!_oxMemcached_addMemcachedServer($oMemcache, $server)) {
                 $aErrors[] = $this->translate('strInvalidServerAddress') . " " . $server;
             }
         }
@@ -83,19 +77,16 @@ class Plugins_DeliveryCacheStore_oxMemcached_oxMemcached extends Plugins_Deliver
                 !is_numeric($aConf[$this->group]['memcachedExpireTime']) ||
                 $aConf[$this->group]['memcachedExpireTime'] <= $aConf['delivery']['cacheExpire']
             )
-        )
-        {
+        ) {
             $aErrors[] = $this->translate('strInvalidExpireTime');
         }
         // Check if memcached server is running
 
-        if (@$oMemcache->getVersion() === false)
-        {
+        if (@$oMemcache->getVersion() === false) {
             $aErrors[] = $this->translate('strCouldntConnectToMemcached');
         }
 
-        if (count($aErrors) > 0)
-        {
+        if (count($aErrors) > 0) {
             return $aErrors;
         }
         return true;
@@ -105,6 +96,7 @@ class Plugins_DeliveryCacheStore_oxMemcached_oxMemcached extends Plugins_Deliver
      * A function to delete a single cache entry
      *
      * @param string $filename The cache entry filename (hashed name)
+     *
      * @return bool True if the entres were succesfully deleted
      */
     function _deleteCacheFile($filename)
@@ -129,4 +121,5 @@ class Plugins_DeliveryCacheStore_oxMemcached_oxMemcached extends Plugins_Deliver
         return @$oMemcache->flush();
     }
 }
+
 ?>

--- a/plugins_repo/openXDeliveryCacheStore/plugins/deliveryCacheStore/oxMemcached/oxMemcached.class.php
+++ b/plugins_repo/openXDeliveryCacheStore/plugins/deliveryCacheStore/oxMemcached/oxMemcached.class.php
@@ -44,7 +44,7 @@ class Plugins_DeliveryCacheStore_oxMemcached_oxMemcached extends Plugins_Deliver
         $aConf = $GLOBALS['_MAX']['CONF'];
 
         // Check if memcached is enabled in php.ini
-        if (!class_exists('Memcached'))
+        if (!class_exists('Memcached') && !class_exists('Memcache'))
         {
             return array($this->translate('strNoMemcacheModuleInPhp'));
         }
@@ -63,7 +63,13 @@ class Plugins_DeliveryCacheStore_oxMemcached_oxMemcached extends Plugins_Deliver
         {
             return $this->translate('strEmptyServerList', array('plugin-settings.php?group=oxMemcached'));
         }
-        $oMemcache = new Memcached();
+
+        if(class_exists('Memcached')){
+            $oMemcache = new Memcached();
+        } else {
+            $oMemcache = new Memcache();
+        }
+
         foreach ($aServers as $server)
         {
             if (!_oxMemcached_addMemcachedServer($oMemcache, $server))

--- a/plugins_repo/openXDeliveryCacheStore/plugins/deliveryCacheStore/oxMemcached/oxMemcached.class.php
+++ b/plugins_repo/openXDeliveryCacheStore/plugins/deliveryCacheStore/oxMemcached/oxMemcached.class.php
@@ -44,7 +44,7 @@ class Plugins_DeliveryCacheStore_oxMemcached_oxMemcached extends Plugins_Deliver
         $aConf = $GLOBALS['_MAX']['CONF'];
 
         // Check if memcached is enabled in php.ini
-        if (!class_exists('Memcache'))
+        if (!class_exists('Memcached'))
         {
             return array($this->translate('strNoMemcacheModuleInPhp'));
         }
@@ -63,7 +63,7 @@ class Plugins_DeliveryCacheStore_oxMemcached_oxMemcached extends Plugins_Deliver
         {
             return $this->translate('strEmptyServerList', array('plugin-settings.php?group=oxMemcached'));
         }
-        $oMemcache = new Memcache();
+        $oMemcache = new Memcached();
         foreach ($aServers as $server)
         {
             if (!_oxMemcached_addMemcachedServer($oMemcache, $server))

--- a/plugins_repo/openXDeliveryCacheStore/plugins/deliveryCacheStore/oxMemcached/oxMemcached.delivery.php
+++ b/plugins_repo/openXDeliveryCacheStore/plugins/deliveryCacheStore/oxMemcached/oxMemcached.delivery.php
@@ -64,7 +64,7 @@ function Plugin_deliveryCacheStore_oxMemcached_oxMemcached_Delivery_cacheStore($
     // @ - to catch "memcached errno=10054: An existing connection was forcibly closed by the remote host", when one of servers is down
     $result = @$oMemcache->replace($filename, $serializedCacheExport, false, $expiryTime);
     if ($result !== true) {
-        // Memcache set/replece can return null on error, so ensure, that for all errors results if false
+        // Memcached set/replace can return null on error, so ensure, that for all errors results if false
         // @ - to catch "memcached errno=10054: An existing connection was forcibly closed by the remote host", when one of servers is down
         if (@$oMemcache->set($filename, $serializedCacheExport, false, $expiryTime) !== true) {
             return false;
@@ -74,9 +74,9 @@ function Plugin_deliveryCacheStore_oxMemcached_oxMemcached_Delivery_cacheStore($
 }
 
 /**
- * Return current Memcache instance
+ * Return current Memcached instance
  *
- * @return Memcache
+ * @return Memcached
  */
 function _oxMemcached_getMemcache(){
     if (!isset($GLOBALS['OA_Delivery_Cache']['MemcachedObject'])) {
@@ -86,17 +86,17 @@ function _oxMemcached_getMemcache(){
 }
 
 /**
- * Function to initialize Memcache connection
- * Memcache function is stored in $GLOBALS['OA_Delivery_Cache']['MemcachedObject']
+ * Function to initialize Memcached connection
+ * Memcached function is stored in $GLOBALS['OA_Delivery_Cache']['MemcachedObject']
  *
- * @return Memcache|bool Memcache object or false on errors
+ * @return Memcached|bool Memcached object or false on errors
  */
 function _oxMemcached_MemcachedInit() {
     // Don't use memcached if there is no extension in PHP
-    if (!class_exists('Memcache')){
+    if (!class_exists('Memcached')){
         return false;
     }
-    $oMemcache = new Memcache();
+    $oMemcache = new Memcached();
 
     $aServers = (explode(',', $GLOBALS['_MAX']['CONF']['oxMemcached']['memcachedServers']));
     $serversAdded = false;
@@ -117,8 +117,8 @@ function _oxMemcached_MemcachedInit() {
  * Split given server address to host and port
  * Host can be unix:///path!
  *
- * @param Memcache $oMemcache Memcache instance
- * @param string $serverAddress memcache server adres in format host:port
+ * @param Memcached $oMemcache Memcached instance
+ * @param string $serverAddress memcached server address in format host:port
  * @return bool
  */
 function _oxMemcached_addMemcachedServer(&$oMemcache, $serverAddress) {

--- a/plugins_repo/openXDeliveryCacheStore/plugins/deliveryCacheStore/oxMemcached/oxMemcached.delivery.php
+++ b/plugins_repo/openXDeliveryCacheStore/plugins/deliveryCacheStore/oxMemcached/oxMemcached.delivery.php
@@ -21,6 +21,7 @@
  * Function to fetch a cache entry
  *
  * @param string $filename The name of file where cache entry is stored
+ *
  * @return mixed False on error, or the cache content
  */
 function Plugin_deliveryCacheStore_oxMemcached_oxMemcached_Delivery_cacheRetrieve($filename)
@@ -42,7 +43,8 @@ function Plugin_deliveryCacheStore_oxMemcached_oxMemcached_Delivery_cacheRetriev
  * A function to store content a cache entry.
  *
  * @param string $filename The filename where cache entry is stored
- * @param array $cache_contents  The cache content
+ * @param array  $cache_contents The cache content
+ *
  * @return bool True if the entry was succesfully stored
  */
 function Plugin_deliveryCacheStore_oxMemcached_oxMemcached_Delivery_cacheStore($filename, $cache_contents)
@@ -55,14 +57,14 @@ function Plugin_deliveryCacheStore_oxMemcached_oxMemcached_Delivery_cacheStore($
     $expiryTime = 0;
     if (!empty($cache_contents['cache_expire'])) {
         $expiryTime = $cache_contents['cache_expire'];
-    } else if (is_numeric($GLOBALS['_MAX']['CONF']['oxMemcached']['memcachedExpireTime'])) {
+    } elseif (is_numeric($GLOBALS['_MAX']['CONF']['oxMemcached']['memcachedExpireTime'])) {
         $expiryTime = $GLOBALS['_MAX']['CONF']['oxMemcached']['memcachedExpireTime'];
     }
     $serializedCacheExport = serialize($cache_contents);
 
     // Store serialized cache
     // @ - to catch "memcached errno=10054: An existing connection was forcibly closed by the remote host", when one of servers is down
-    if($oMemcache instanceof Memcached) {
+    if ($oMemcache instanceof Memcached) {
         $result = @$oMemcache->replace($filename, $serializedCacheExport, $expiryTime);
     } else {
         $result = @$oMemcache->replace($filename, $serializedCacheExport, false, $expiryTime);
@@ -70,12 +72,12 @@ function Plugin_deliveryCacheStore_oxMemcached_oxMemcached_Delivery_cacheStore($
     if ($result !== true) {
         // Memcached set/replace can return null on error, so ensure, that for all errors results if false
         // @ - to catch "memcached errno=10054: An existing connection was forcibly closed by the remote host", when one of servers is down
-        if($oMemcache instanceof Memcached) {
+        if ($oMemcache instanceof Memcached) {
             $setResult = @$oMemcache->set($filename, $serializedCacheExport, $expiryTime);
         } else {
             $setResult = @$oMemcache->set($filename, $serializedCacheExport, false, $expiryTime);
         }
-        if($setResult !== true) {
+        if ($setResult !== true) {
             return false;
         }
     }
@@ -87,9 +89,10 @@ function Plugin_deliveryCacheStore_oxMemcached_oxMemcached_Delivery_cacheStore($
  *
  * @return Memcached|Memcache|bool
  */
-function _oxMemcached_getMemcache(){
+function _oxMemcached_getMemcache()
+{
     if (!isset($GLOBALS['OA_Delivery_Cache']['MemcachedObject'])) {
-         return _oxMemcached_MemcachedInit();
+        return _oxMemcached_MemcachedInit();
     }
     return $GLOBALS['OA_Delivery_Cache']['MemcachedObject'];
 }
@@ -100,13 +103,14 @@ function _oxMemcached_getMemcache(){
  *
  * @return Memcached|Memcache|bool Memcached object or false on errors
  */
-function _oxMemcached_MemcachedInit() {
+function _oxMemcached_MemcachedInit()
+{
     // Don't use memcached if there is no extension in PHP
-    if (!class_exists('Memcached') && !class_exists('Memcache')){
+    if (!class_exists('Memcached') && !class_exists('Memcache')) {
         return false;
     }
 
-    if(class_exists('Memcached')) {
+    if (class_exists('Memcached')) {
         $oMemcache = new Memcached();
     } else {
         $oMemcache = new Memcache();
@@ -132,20 +136,22 @@ function _oxMemcached_MemcachedInit() {
  * Host can be unix:///path!
  *
  * @param Memcached|Memcache $oMemcache Memcached instance
- * @param string $serverAddress memcached server address in format host:port
+ * @param string             $serverAddress memcached server address in format host:port
+ *
  * @return bool
  */
-function _oxMemcached_addMemcachedServer(&$oMemcache, $serverAddress) {
+function _oxMemcached_addMemcachedServer(&$oMemcache, $serverAddress)
+{
     $serverAddress = trim($serverAddress);
     if (($colonPos = strrpos($serverAddress, ':')) === false) {
         return false;
     }
-    $port = substr($serverAddress,$colonPos+1);
+    $port = substr($serverAddress, $colonPos + 1);
     if (!is_numeric($port)) {
         return false;
     }
     // @ - to catch memcached notices on errors
-    return @$oMemcache->addServer(substr($serverAddress,0,$colonPos), $port);
+    return @$oMemcache->addServer(substr($serverAddress, 0, $colonPos), $port);
 }
 
 ?>


### PR DESCRIPTION
Memcache is not available for PHP 7, we can only use the newer Memcached extension.