### PR TITLE
Exclude trailing query string parameters from ad destination URL

### DIFF
--- a/lib/max/Delivery/querystring.php
+++ b/lib/max/Delivery/querystring.php
@@ -34,7 +34,12 @@ function MAX_querystringConvertParams()
         $pos = strpos($qs, $destStr);
     }
     if ($pos !== false) {
-        $dest = urldecode(substr($qs, $pos + strlen($destStr)));
+        $endPos = strpos($qs, '&', $pos + strlen($destStr));
+        if ($endPos) {
+          $dest = urldecode(substr($qs, $pos + strlen($destStr), $endPos - $pos - strlen($destStr)));
+        } else {
+          $dest = urldecode(substr($qs, $pos + strlen($destStr)));
+        }
         $qs = substr($qs, 0, $pos);
     }
     // 2.  Parse the remaining string


### PR DESCRIPTION
Addresses issue #754.  Constrains the length of the substring pulled from the query string when finding the destination URL on link click. If additional query string parameters were added, they are not included in the destination url.