### PR TITLE
Fix PEAR Date bug and allow REST API to set campaign expire_time to never expire

### DIFF
--- a/lib/OA/Dll/Campaign.php
+++ b/lib/OA/Dll/Campaign.php
@@ -258,13 +258,17 @@ class OA_Dll_Campaign extends OA_Dll
             $campaignData['activate_time'] = $oDate->getDate(DATE_FORMAT_ISO);
         }
         if (is_object($oEndDate)) {
-            $oDate = new Date($oEndDate);
-            $oDate->setTZ($oNow->tz);
-            $oDate->setHour(23);
-            $oDate->setMinute(59);
-            $oDate->setSecond(59);
-            $oDate->toUTC();
-            $campaignData['expire_time'] = $oDate->getDate(DATE_FORMAT_ISO);
+            if ($oEndDate->year > 0) {
+                $oDate = new Date($oEndDate);
+                $oDate->setTZ($oNow->tz);
+                $oDate->setHour(23);
+                $oDate->setMinute(59);
+                $oDate->setSecond(59);
+                $oDate->toUTC();
+                $campaignData['expire_time'] = $oDate->getDate(DATE_FORMAT_ISO);
+            } else {
+                $campaignData['expire_time'] = OX_DATAOBJECT_NULL;
+            }
         }
 
         $campaignData['views']        = $oCampaign->impressions;

--- a/lib/pear/Date/Calc.php
+++ b/lib/pear/Date/Calc.php
@@ -1203,7 +1203,7 @@ class Date_Calc
 
     function dateToDays($day,$month,$year)
     {
-
+        $year = sprintf("%04d", $year);
         $century = (int) substr($year,0,2);
         $year = (int) substr($year,2,2);
 


### PR DESCRIPTION
While working on a request for adding the ability to set the expire time of a campaing to never expire I found two components in the main ad server which prohibited this. While examining the web ui I saw that it is passing a NULL to set the expire time to never expire, so I set out to make the REST API do the same. Internally this NULL is converted into a PEAR Date which then becomes an (invalid) date in the year zero. However due to a bug in PEAR Date the date got mangled during conversion to UTC. Fixing that is one part of this PR. The other part is handling the year zero date inside the campaign dll and converting it back into a proper SQL NULL.
