### PR TITLE
Better replace arbitrary macros

### DIFF
--- a/lib/max/Delivery/adRender.php
+++ b/lib/max/Delivery/adRender.php
@@ -140,7 +140,7 @@ function MAX_adRender(&$aBanner, $zoneId=0, $source='', $target='', $ct0='', $wi
     $websiteid = (!empty($aBanner['affiliate_id'])) ? $aBanner['affiliate_id'] : '0';
     $replace = array($time, $random, $target, $urlPrefix, $aBanner['ad_id'], $zoneId, $source, urlencode($locReplace), $aBanner['width'], $aBanner['height'], $websiteid, $aBanner['campaign_id'], $aBanner['client_id'], $referer);
 
-    preg_match_all('#{(.*?)(_enc)?}#', $code, $macros);
+    preg_match_all('#{([a-zA-Z0-9_]*?)(_enc)?}#', $code, $macros);
     for ($i=0;$i<count($macros[1]);$i++) {
         if (!in_array($macros[0][$i], $search) && isset($_REQUEST[$macros[1][$i]])) {
             $search[] = $macros[0][$i];


### PR DESCRIPTION
The replace of arbitrary macros does not work when banner code contains pairs of square brackets. 

It would fail to replace anything in case of the following banner code:
```
<script>
var options = { variable1: {variable1} }
</script>
```