### PR TITLE
Update Tag.php

### DIFF
--- a/lib/pear/HTML/Template/Flexy/Compiler/Flexy/Tag.php
+++ b/lib/pear/HTML/Template/Flexy/Compiler/Flexy/Tag.php
@@ -1045,7 +1045,8 @@ class HTML_Template_Flexy_Compiler_Flexy_Tag {
         $trans_tbl = get_html_translation_table (HTML_ENTITIES);
         $trans_tbl = array_flip ($trans_tbl);
         $ret = strtr ($in, $trans_tbl);
-        return preg_replace('/&#(\d+);/me', "chr('\\1')",$ret);
+        //return preg_replace('/&#(\d+);/me', "chr('\\1')",$ret);
+        return preg_replace_callback('/&#(\d+);/me', "chr('\\1')",$ret);
     }
 
 


### PR DESCRIPTION
/e modifier is not any more supported by preg_replace in php7. (Ref: http://php.net/manual/en/function.preg-replace.php)
The PHP Official documentation recomend use preg_replace_callback instead.

