### PR TITLE
getBaseUrl fix for installation behind SSL-enabled reverse proxy

### DIFF
--- a/lib/OX/Admin/UI/Controller/Request.php
+++ b/lib/OX/Admin/UI/Controller/Request.php
@@ -191,7 +191,7 @@ class OX_Admin_UI_Controller_Request
     public function getBaseUrl()
     {
         if ($this->baseUrl == null) {
-            $baseUrl = 'http'.((isset($_SERVER["HTTPS"]) && ($_SERVER["HTTPS"] == "on")) ? 's' : '').'://';
+            $baseUrl = 'http'.(((isset($_SERVER["HTTPS"]) && ($_SERVER["HTTPS"] == "on")) || (isset($_SERVER["HTTP_X_REAL_SSL"]) && ($_SERVER["HTTP_X_REAL_SSL"] == "yes") )) ? 's' : '').'://';
             $baseUrl .= OX_getHostNameWithPort().substr($_SERVER['REQUEST_URI'],0,strrpos($_SERVER['REQUEST_URI'], '/')+1);
 
             $this->baseUrl = $baseUrl;


### PR DESCRIPTION
When Revive runs under Apache on non-SSL local host, and is being served to users through a reverse proxy like Nginx, then the variable $_SERVER["HTTPS"] would always have a negative value. To detect such environment, "X-Real-SSL" header should be used.