### PR TITLE
generate https iframe links if admin is https

### DIFF
--- a/plugins_repo/openXInvocationTags/plugins/invocationTags/oxInvocationTags/adframe.class.php
+++ b/plugins_repo/openXInvocationTags/plugins/invocationTags/oxInvocationTags/adframe.class.php
@@ -136,7 +136,12 @@ class Plugins_InvocationTags_OxInvocationTags_adframe extends Plugins_Invocation
 
         if (empty($mi->frame_width )) { $mi->frame_width  = $mi->width; }
         if (empty($mi->frame_height)) { $mi->frame_height = $mi->height; }
-        $buffer .= "<iframe id='{$uniqueid}' name='{$uniqueid}' src='".MAX_commonConstructDeliveryUrl($conf['file']['frame']);
+        $buffer .= "<iframe id='{$uniqueid}' name='{$uniqueid}'";
+        if ($GLOBALS['_MAX']['SSL_REQUEST']) { 
+          $buffer .= " src='".MAX_commonConstructSecureDeliveryUrl($conf['file']['frame']);
+        } else {
+          $buffer .= " src='".MAX_commonConstructDeliveryUrl($conf['file']['frame']);
+        }
         if (sizeof($mi->parameters) > 0) {
             $buffer .= "?".implode ("&amp;", $mi->parameters);
         }

--- a/plugins_repo/openXInvocationTags/plugins/invocationTags/oxInvocationTags/adlayer.class.php
+++ b/plugins_repo/openXInvocationTags/plugins/invocationTags/oxInvocationTags/adlayer.class.php
@@ -118,15 +118,17 @@ class Plugins_InvocationTags_OxInvocationTags_adlayer extends Plugins_Invocation
   * the click tracking URL if this ad is to be delivered through a 3rd
   * party (non-Max) adserver.
   *"),
-            'SSL Delivery Comment' => $this->translate("
-  * This tag has been generated for use on a non-SSL page. If this tag
-  * is to be placed on an SSL page, change the
-  *   'http://%s/...'
-  * to
-  *   'https://%s/...'
-  *", array ($conf['webpath']['delivery'],$conf['webpath']['deliverySSL'])),
             'SSL Backup Comment'   => '',
             );
+        if (! $GLOBALS['_MAX']['SSL_REQUEST']) {
+        $aComments['SSL Delivery Comment'] = $this->translate("
+          * This tag has been generated for use on a non-SSL page. If this tag
+          * is to be placed on an SSL page, change the
+          *   'http://%s/...'
+          * to
+          *   'https://%s/...'
+          *", array ($conf['webpath']['delivery'],$conf['webpath']['deliverySSL']));
+        }
         if (isset($GLOBALS['layerstyle']) &&
             ($GLOBALS['layerstyle'] == 'geocities' || $GLOBALS['layerstyle'] == 'simple')) {
             $aComments['Comment'] = $this->translate("


### PR DESCRIPTION
we serve all of our ads over https. occasionally the person setting up the ads forgets to change the iframe links from http to https. hopefully this is an acceptable solution to get merged in.

if the admin page is being served over https it will generate iframe links with https, and vice versa if the admin is on http.
