### PR TITLE
Update async.js

### DIFF
--- a/www/delivery_dev/async.js
+++ b/www/delivery_dev/async.js
@@ -239,6 +239,7 @@
                     i.height = data.height > 0 ? data.height : 0;
                     s.border = 0;
                     s.overflow = "hidden";
+                    s.verticalAlign = 'bottom';
 
                     return i;
                 },


### PR DESCRIPTION
By the asycnronous delivery occuring an empty space after the iframe as iframe is an inline HTML-Element. The solution could be in 2 ways: adding display:block (than you need to add some more rules) or adding vertical-align:bottom CSS rule, which removes this empty space. As Google DFP is using the vertical-align rule. I added this to the async.js file.

Now I made the change in delivery_dev, as it should be.