### PR TITLE
[BUGFIX] Localized support for Rebuild banner cache

### DIFF
--- a/www/admin/maintenance-banners-check.php
+++ b/www/admin/maintenance-banners-check.php
@@ -60,7 +60,7 @@ if (!empty($action) && ($action == 'Rebuild')) {
         echo $GLOBALS['strBannerCacheDifferencesFound'];
         echo "<form action='' METHOD='GET'>";
         echo "<input type='hidden' name='token' value='".htmlspecialchars(phpAds_SessionGetToken(), ENT_QUOTES)."' />";
-        echo "<input type='submit' name='action' value='{$GLOBALS['strBannerCacheRebuildButton']}' />";
+        echo "<button type='submit' name='action' value='Rebuild'>{$GLOBALS['strBannerCacheRebuildButton']}</button>";
         echo "</form>";
     } else {
         _showPageHeader();


### PR DESCRIPTION
The [Rebuild button haven't worked for years](https://forum.revive-adserver.com/topic/1970-banner-cache-rebuild/?tab=comments#comment-6375), if any non-English language was used due to action obviously not being "Rebuild".

By using a `<button>` enables support for a [localized button while keeping the expected action](https://stackoverflow.com/a/4171680).