### PR TITLE
Revive_ClientTZ_Support

### DIFF
--- a/lib/OA/Dal/Statistics.php
+++ b/lib/OA/Dal/Statistics.php
@@ -25,31 +25,47 @@ class OA_Dal_Statistics extends OA_Dal
     /**
      * Get SQL where for statistics methods.
      *
-     *  @access public
+     * @access public
      *
-     * @param Date   $oStartDate
-     * @param Date   $oEndDate
-     * @param bool   $localTZ
+     * @param Date $oStartDate
+     * @param Date $oEndDate
+     * @param bool $localTZ
      * @param string $dateField
      *
      * @return string
      */
-    function getWhereDate($oStartDate, $oEndDate, $localTZ = false, $dateField = 's.date_time')
+    function getWhereDate($oStartDate, $oEndDate, $localTZ = false, $dateField = 's.date_time', $timeZone = null)
     {
         $where = '';
+
+        $hour = null;
+        $minute = null;
+        $second = null;
+
         if (isset($oStartDate)) {
-            $oStart = $this->setTimeAndReturnUTC($oStartDate, $localTZ, 0, 0, 0);
+
+            $hour = isset($timeZone) ? $oStartDate->hour : 0;
+            $minute = isset($timeZone) ? $oStartDate->minute : 0;
+            $second = isset($timeZone) ? $oStartDate->second : 0;
+
+            $oStart = $this->setTimeAndReturnUTC($oStartDate, $localTZ, $hour, $minute, $second, $timeZone);
             $where .= '
-                AND ' .
-                $dateField .' >= '.$this->oDbh->quote($oStart->getDate(DATE_FORMAT_ISO), 'timestamp');
+                    AND ' .
+                $dateField . ' >= ' . $this->oDbh->quote($oStart->getDate(DATE_FORMAT_ISO), 'timestamp');
         }
 
         if (isset($oEndDate)) {
-            $oEnd = $this->setTimeAndReturnUTC($oEndDate, $localTZ, 23, 59, 59);
+
+            $hour = isset($timeZone) ? $oEndDate->hour : 23;
+            $minute = isset($timeZone) ? $oEndDate->minute : 59;
+            $second = isset($timeZone) ? $oEndDate->second : 59;
+
+            $oEnd = $this->setTimeAndReturnUTC($oEndDate, $localTZ, $hour, $minute, $second, $timeZone);
             $where .= '
-                AND ' .
-                $dateField .' <= '.$this->oDbh->quote($oEnd->getDate(DATE_FORMAT_ISO), 'timestamp');
+                    AND ' .
+                $dateField . ' <= ' . $this->oDbh->quote($oEnd->getDate(DATE_FORMAT_ISO), 'timestamp');
         }
+
         return $where;
     }
 
@@ -82,9 +98,9 @@ class OA_Dal_Statistics extends OA_Dal
      * @param int $second
      * @return Date
      */
-    private function setTimeAndReturnUTC($oDate, $localTZ = false, $hour = 0, $minute = 0, $second = 0)
+    private function setTimeAndReturnUTC($oDate, $localTZ = false, $hour = 0, $minute = 0, $second = 0, $timeZone = null)
     {
-        $oTz = $this->getTimeZone($localTZ);
+        $oTz = isset($timeZone) ? new DateTimeZone($timeZone) : $this->getTimeZone($localTZ);
 
         $oDateCopy = new Date($oDate);
         $oDateCopy->setHour($hour);
@@ -107,7 +123,7 @@ class OA_Dal_Statistics extends OA_Dal
      */
     function getDailyStatsAsArray($query, $localTZ = false)
     {
-        $oTz  = $this->getTimeZone($localTZ);
+        $oTz = $this->getTimeZone($localTZ);
         if ($oTz->getShortName() == 'UTC') {
             // Disable TZ conversion
             $oTz = false;
@@ -146,8 +162,8 @@ class OA_Dal_Statistics extends OA_Dal
     /**
      * Add quote for table name.
      *
-	 * @access public
-	 *
+     * @access public
+     *
      * @param string $tableName
      *
      * @return string  quotes table name
@@ -157,8 +173,8 @@ class OA_Dal_Statistics extends OA_Dal
         $aConf = $GLOBALS['_MAX']['CONF'];
 
         return $this->oDbh->quoteIdentifier(
-                            $aConf['table']['prefix'].$aConf['table'][$tableName],
-                            true);
+            $aConf['table']['prefix'] . $aConf['table'][$tableName],
+            true);
     }
 
 }

--- a/lib/OA/Dal/Statistics.php
+++ b/lib/OA/Dal/Statistics.php
@@ -177,6 +177,27 @@ class OA_Dal_Statistics extends OA_Dal
             true);
     }
 
+
+
+    /**
+     * A private method used to return a copy of a DateTime with converted to specific time zone.
+     *
+     * @param DateTime $dateTime
+     * @param bool $localTZ
+     * @param string $timeZone
+     * @return DateTime
+     */
+    function setDateTimeZone($dateTime, $localTZ = false, $timeZone = null)
+    {
+        $oTz = isset($timeZone) ? new DateTimeZone($timeZone) : $this->getTimeZone($localTZ);
+
+        $oDateCopy = new DateTime($dateTime, new DateTimeZone('UTC'));
+        $oDateCopy->setTimezone($oTz);
+
+        return $oDateCopy;
+    }
+
+
 }
 
 ?>

--- a/lib/OA/Dal/Statistics/Campaign.php
+++ b/lib/OA/Dal/Statistics/Campaign.php
@@ -33,6 +33,7 @@ class OA_Dal_Statistics_Campaign extends OA_Dal_Statistics
     * @param date $oStartDate The date from which to get statistics (inclusive)
     * @param date $oEndDate The date to which to get statistics (inclusive)
     * @param bool $localTZ Should stats be using the manager TZ or UTC?
+    * @param string $timeZone Timezone sent by the client that makes the request (optional)
     *
     * @return array Each row containing:
     * <ul>
@@ -44,12 +45,14 @@ class OA_Dal_Statistics_Campaign extends OA_Dal_Statistics
     * </ul>
     *
     */
-    function getCampaignDailyStatistics($campaignId, $oStartDate, $oEndDate, $localTZ = false)
+    function getCampaignDailyStatistics($campaignId, $oStartDate, $oEndDate, $localTZ = false, $timeZone = null)
     {
         $campaignId     = $this->oDbh->quote($campaignId, 'integer');
         $tableCampaigns = $this->quoteTableName('campaigns');
         $tableBanners   = $this->quoteTableName('banners');
         $tableSummary   = $this->quoteTableName('data_summary_ad_hourly');
+
+        $dateField = (isset($timeZone)) ? "CONVERT_TZ(s.date_time, 'UTC','" . $timeZone . "')" : "s.date_time";
 
         $aConf = $GLOBALS['_MAX']['CONF'];
 
@@ -72,7 +75,7 @@ class OA_Dal_Statistics_Campaign extends OA_Dal_Statistics
                 m.campaignid = b.campaignid
                 AND
                 b.bannerid = s.ad_id
-                " . $this->getWhereDate($oStartDate, $oEndDate, $localTZ) . "
+                " . $this->getWhereDate($oStartDate, $oEndDate, $localTZ, $dateField, $timeZone) . "
             GROUP BY
                 day,
                 hour
@@ -219,6 +222,7 @@ class OA_Dal_Statistics_Campaign extends OA_Dal_Statistics
     * @param date $oStartDate The date from which to get statistics (inclusive)
     * @param date $oEndDate The date to which to get statistics (inclusive)
     * @param bool $localTZ Should stats be using the manager TZ or UTC?
+    * @param string $timeZone Timezone sent by the client that makes the request (optional)
     *
     * @return RecordSet
     * <ul>
@@ -233,7 +237,7 @@ class OA_Dal_Statistics_Campaign extends OA_Dal_Statistics
     * </ul>
     *
     */
-    function getCampaignZoneStatistics($campaignId, $oStartDate, $oEndDate, $localTZ = false)
+    function getCampaignZoneStatistics($campaignId, $oStartDate, $oEndDate, $localTZ = false, $timeZone = null)
     {
         $campaignId      = $this->oDbh->quote($campaignId, 'integer');
         $tableCampaigns  = $this->quoteTableName('campaigns');
@@ -241,6 +245,8 @@ class OA_Dal_Statistics_Campaign extends OA_Dal_Statistics
         $tableZones      = $this->quoteTableName('zones');
         $tableAffiliates = $this->quoteTableName('affiliates');
         $tableSummary    = $this->quoteTableName('data_summary_ad_hourly');
+
+        $dateField = (isset($timeZone)) ? "CONVERT_TZ(s.date_time, 'UTC','" . $timeZone . "')" : "s.date_time";
 
 		$query = "
             SELECT
@@ -272,7 +278,7 @@ class OA_Dal_Statistics_Campaign extends OA_Dal_Statistics
                 p.affiliateid = z.affiliateid
                 AND
                 z.zoneid = s.zone_id
-                " . $this->getWhereDate($oStartDate, $oEndDate, $localTZ) . "
+                " . $this->getWhereDate($oStartDate, $oEndDate, $localTZ, $dateField, $timeZone) . "
             GROUP BY
                 p.affiliateid, p.name,
                 z.zoneid, z.zonename
@@ -288,6 +294,7 @@ class OA_Dal_Statistics_Campaign extends OA_Dal_Statistics
      * @param date $oStartDate The date from which to get statistics (inclusive)
      * @param date $oEndDate The date to which to get statistics (inclusive)
      * @param bool $localTZ Should stats be using the manager TZ or UTC?
+     * @param string $timeZone Timezone sent by the client that makes the request (optional)
      *
      * @return MDB2_Result_Common
      *<ul>
@@ -303,7 +310,7 @@ class OA_Dal_Statistics_Campaign extends OA_Dal_Statistics
      *                             with each variable as an array('variableName' => 'variableValue')
      *</ul>
      */
-    public function getCampaignConversionStatistics($campaignId, $oStartDate, $oEndDate, $localTZ = false)
+    public function getCampaignConversionStatistics($campaignId, $oStartDate, $oEndDate, $localTZ = false, $timeZone = null)
     {
         $tableBanners = $this->quoteTableName('banners');
         $tableVariables = $this->quoteTableName('variables');
@@ -311,7 +318,10 @@ class OA_Dal_Statistics_Campaign extends OA_Dal_Statistics
         $tableDataIntermadiateAdVariableValue = $this->quoteTableName('data_intermediate_ad_variable_value');
 
         $localTZ = false;
-        $dateField = 'd.tracker_date_time';
+        $dateField = (isset($timeZone)) ? "CONVERT_TZ(d.tracker_date_time, 'UTC','" . $timeZone . "')" : "d.tracker_date_time";
+        $orderBy = (isset($timeZone)) ? "ORDER BY d.tracker_date_time" : "";
+
+
 
         $query = "
             SELECT
@@ -319,7 +329,7 @@ class OA_Dal_Statistics_Campaign extends OA_Dal_Statistics
                 b.campaignid as campaignid,
                 d.tracker_id as trackerid,
                 d.ad_id as bannerid,
-                d.tracker_date_time as tracker_date_time,
+                {$dateField} as tracker_date_time,
                 d.connection_date_time as connection_date_time,
                 d.connection_status as conversionstatus,
                 d.tracker_ip_address as userip,
@@ -333,9 +343,11 @@ class OA_Dal_Statistics_Campaign extends OA_Dal_Statistics
                 left JOIN {$tableVariables} AS v ON (i.tracker_variable_id = v.variableid)
             WHERE
                 TRUE " . // Bit of a hack due to how getWhereDate works.
-                $this->getWhereDate($oStartDate, $oEndDate, $localTZ, $dateField) . "
+                $this->getWhereDate($oStartDate, $oEndDate, $localTZ, $dateField, $timeZone) . "
                 AND b.campaignid = " . $campaignId . "
-            ";
+            " . $orderBy;
+
+
 
         RV::disableErrorHandling();
         $rsResult = $this->oDbh->query($query);

--- a/lib/OA/Dal/Statistics/Campaign.php
+++ b/lib/OA/Dal/Statistics/Campaign.php
@@ -52,7 +52,7 @@ class OA_Dal_Statistics_Campaign extends OA_Dal_Statistics
         $tableBanners   = $this->quoteTableName('banners');
         $tableSummary   = $this->quoteTableName('data_summary_ad_hourly');
 
-        $dateField = (isset($timeZone)) ? "CONVERT_TZ(s.date_time, 'UTC','" . $timeZone . "')" : "s.date_time";
+        $dateField = 's.date_time';
 
         $aConf = $GLOBALS['_MAX']['CONF'];
 
@@ -246,7 +246,7 @@ class OA_Dal_Statistics_Campaign extends OA_Dal_Statistics
         $tableAffiliates = $this->quoteTableName('affiliates');
         $tableSummary    = $this->quoteTableName('data_summary_ad_hourly');
 
-        $dateField = (isset($timeZone)) ? "CONVERT_TZ(s.date_time, 'UTC','" . $timeZone . "')" : "s.date_time";
+        $dateField = 's.date_time';
 
 		$query = "
             SELECT
@@ -318,7 +318,7 @@ class OA_Dal_Statistics_Campaign extends OA_Dal_Statistics
         $tableDataIntermadiateAdVariableValue = $this->quoteTableName('data_intermediate_ad_variable_value');
 
         $localTZ = false;
-        $dateField = (isset($timeZone)) ? "CONVERT_TZ(d.tracker_date_time, 'UTC','" . $timeZone . "')" : "d.tracker_date_time";
+        $dateField = 'd.tracker_date_time';
         $orderBy = (isset($timeZone)) ? "ORDER BY d.tracker_date_time" : "";
 
 
@@ -358,7 +358,7 @@ class OA_Dal_Statistics_Campaign extends OA_Dal_Statistics
             $aResult[$row['conversionid']] = array('campaignID' => $row['campaignid'],
                                                    'trackerID' =>  $row['trackerid'],
                                                    'bannerID' => $row['bannerid'],
-                                                   'conversionTime' => $row['tracker_date_time'],
+                                                   'conversionTime' => $this->setDateTimeZone($row['tracker_date_time'], $localTZ, $timeZone)->format('Y-m-d H:i:s'),
                                                    'conversionStatus' => $row['conversionstatus'],
                                                    'userIp' => $row['userip'],
                                                    'action' => $row['action'],

--- a/lib/OA/Dal/Statistics/Zone.php
+++ b/lib/OA/Dal/Statistics/Zone.php
@@ -165,7 +165,7 @@ class OA_Dal_Statistics_Zone extends OA_Dal_Statistics
         $tableBanners   = $this->quoteTableName('banners');
         $tableSummary   = $this->quoteTableName('data_summary_ad_hourly');
 
-        $dateField = (isset($timeZone)) ? "CONVERT_TZ(s.date_time, 'UTC','" . $timeZone . "')" : "s.date_time";
+        $dateField = 's.date_time';
 
 		$query = "
             SELECT
@@ -428,7 +428,7 @@ class OA_Dal_Statistics_Zone extends OA_Dal_Statistics
                 AND
                 b.campaignid = c.campaignid
 
-                " . $this->getWhereDate($oStartDate, $oEndDate, $localTZ) . "
+                " . $this->getWhereDate($oStartDate, $oEndDate) . "
             GROUP BY
                 s.zone_id
             HAVING
@@ -496,7 +496,7 @@ class OA_Dal_Statistics_Zone extends OA_Dal_Statistics
                 AND
                 b.campaignid = c.campaignid
 
-                " . $this->getWhereDate($oStartDate, $oEndDate, $localTZ) . "
+                " . $this->getWhereDate($oStartDate, $oEndDate) . "
             GROUP BY
                 s.zone_id
             HAVING
@@ -558,7 +558,7 @@ class OA_Dal_Statistics_Zone extends OA_Dal_Statistics
                     AND
                     b.bannerid = s.ad_id
 
-                    " . $this->getWhereDate($oStartDate, $oEndDate, $localTZ) . "
+                    " . $this->getWhereDate($oStartDate, $oEndDate) . "
                 GROUP BY
                     s.zone_id
                 HAVING
@@ -575,7 +575,7 @@ class OA_Dal_Statistics_Zone extends OA_Dal_Statistics
                 WHERE
                     s.zone_id IN (" . implode(',', $aZonesIds) . ")
 
-                    " . $this->getWhereDate($oStartDate, $oEndDate, $localTZ) . "
+                    " . $this->getWhereDate($oStartDate, $oEndDate) . "
                 GROUP BY
                     s.zone_id
                 HAVING

--- a/lib/OA/Dal/Statistics/Zone.php
+++ b/lib/OA/Dal/Statistics/Zone.php
@@ -142,6 +142,7 @@ class OA_Dal_Statistics_Zone extends OA_Dal_Statistics
     * @param date $oStartDate The date from which to get statistics (inclusive)
     * @param date $oEndDate The date to which to get statistics (inclusive)
     * @param bool $localTZ Should stats be using the manager TZ or UTC?
+    * @param string $timeZone Client TZ that is making the request
     *
     * @return RecordSet
     *   <ul>
@@ -156,13 +157,15 @@ class OA_Dal_Statistics_Zone extends OA_Dal_Statistics
     *   </ul>
     *
     */
-    function getZoneCampaignStatistics($zoneId, $oStartDate, $oEndDate, $localTZ = false)
+    function getZoneCampaignStatistics($zoneId, $oStartDate, $oEndDate, $localTZ = false, $timeZone = null)
     {
         $zoneId         = $this->oDbh->quote($zoneId, 'integer');
         $tableClients   = $this->quoteTableName('clients');
         $tableCampaigns = $this->quoteTableName('campaigns');
         $tableBanners   = $this->quoteTableName('banners');
         $tableSummary   = $this->quoteTableName('data_summary_ad_hourly');
+
+        $dateField = (isset($timeZone)) ? "CONVERT_TZ(s.date_time, 'UTC','" . $timeZone . "')" : "s.date_time";
 
 		$query = "
             SELECT
@@ -190,7 +193,7 @@ class OA_Dal_Statistics_Zone extends OA_Dal_Statistics
                 AND
                 b.bannerid = s.ad_id
 
-                " . $this->getWhereDate($oStartDate, $oEndDate, $localTZ) . "
+                " . $this->getWhereDate($oStartDate, $oEndDate, $localTZ, $dateField, $timeZone) . "
             GROUP BY
                 m.campaignid, m.campaignname,
                 c.clientid, c.clientname

--- a/lib/OA/Dll/Campaign.php
+++ b/lib/OA/Dll/Campaign.php
@@ -418,6 +418,7 @@ class OA_Dll_Campaign extends OA_Dll
      * @param date $oEndDate The date to which to get statistics (inclusive)
      * @param bool $localTZ Should stats be using the manager TZ or UTC?
      * @param array &$rsStatisticsData The data returned by the function
+     * @param string $timeZone Timezone sent by the client that makes the request (optional)
      * <ul>
      *   <li><b>day date</b>  The day
      *   <li><b>requests integer</b>  The number of requests for the day
@@ -429,7 +430,7 @@ class OA_Dll_Campaign extends OA_Dll
      * @return boolean  True if the operation was successful and false if not.
      *
      */
-    function getCampaignDailyStatistics($campaignId, $oStartDate, $oEndDate, $localTZ, &$rsStatisticsData)
+    function getCampaignDailyStatistics($campaignId, $oStartDate, $oEndDate, $localTZ, &$rsStatisticsData, $timeZone = null)
     {
         if (!$this->checkStatisticsPermissions($campaignId)) {
             return false;
@@ -438,7 +439,7 @@ class OA_Dll_Campaign extends OA_Dll
         if ($this->_validateForStatistics($campaignId, $oStartDate, $oEndDate)) {
             $dalCampaign = new OA_Dal_Statistics_Campaign;
             $rsStatisticsData = $dalCampaign->getCampaignDailyStatistics($campaignId,
-                $oStartDate, $oEndDate, $localTZ);
+                $oStartDate, $oEndDate, $localTZ, $timeZone);
 
             return true;
         } else {
@@ -541,6 +542,7 @@ class OA_Dll_Campaign extends OA_Dll
      * @param date $oEndDate The date to which to get statistics (inclusive)
      * @param bool $localTZ Should stats be using the manager TZ or UTC?
      * @param array &$rsStatisticsData The data returned by the function
+     * @param string $timeZone Timezone sent by the client that makes the request (optional)
      * <ul>
      *   <li><b>publisherID integer</b> The ID of the publisher
      *   <li><b>publisherName string (255)</b> The name of the publisher
@@ -555,7 +557,7 @@ class OA_Dll_Campaign extends OA_Dll
      * @return boolean  True if the operation was successful and false if not.
      *
      */
-    function getCampaignZoneStatistics($campaignId, $oStartDate, $oEndDate, $localTZ, &$rsStatisticsData)
+    function getCampaignZoneStatistics($campaignId, $oStartDate, $oEndDate, $localTZ, &$rsStatisticsData, $timeZone = null)
     {
         if (!$this->checkStatisticsPermissions($campaignId)) {
             return false;
@@ -564,7 +566,7 @@ class OA_Dll_Campaign extends OA_Dll
         if ($this->_validateForStatistics($campaignId, $oStartDate, $oEndDate)) {
             $dalCampaign = new OA_Dal_Statistics_Campaign;
             $rsStatisticsData = $dalCampaign->getCampaignZoneStatistics($campaignId,
-                $oStartDate, $oEndDate, $localTZ);
+                $oStartDate, $oEndDate, $localTZ, $timeZone);
 
             return true;
         } else {
@@ -580,6 +582,7 @@ class OA_Dll_Campaign extends OA_Dll
      * @param date $oEndDate The date to which to get statistics (inclusive)
      * @param bool $localTZ Should stats be using the manager TZ or UTC?
      * @param array &$rsStatisticsData The data returned by the function each row containing
+     * @param string $timeZone Timezone sent by the client that makes the request (optional)
      * <ul>
      *  <li><b>campaignID integer</b> The ID of the campaign</li>
      *  <li><b>trackerID integer</b> The ID of the tracker</li>
@@ -595,7 +598,7 @@ class OA_Dll_Campaign extends OA_Dll
      *
      */
     public function getCampaignConversionStatistics(
-        $campaignId, $oStartDate, $oEndDate, $localTZ, &$rsStatisticsData)
+        $campaignId, $oStartDate, $oEndDate, $localTZ, &$rsStatisticsData, $timeZone = null)
     {
         if (!$this->checkStatisticsPermissions($campaignId)) {
             return false;
@@ -604,7 +607,7 @@ class OA_Dll_Campaign extends OA_Dll
         if ($this->_validateForStatistics($campaignId, $oStartDate, $oEndDate)) {
             $dalCampaign = new OA_Dal_Statistics_Campaign;
             $rsStatisticsData = $dalCampaign->getCampaignConversionStatistics(
-                $campaignId, $oStartDate, $oEndDate, $localTZ);
+                $campaignId, $oStartDate, $oEndDate, $localTZ, $timeZone);
 
             return true;
         } else {

--- a/lib/OA/Dll/Zone.php
+++ b/lib/OA/Dll/Zone.php
@@ -448,6 +448,7 @@ class OA_Dll_Zone extends OA_Dll
      * @param date $oEndDate The date to which to get statistics (inclusive)
      * @param bool $localTZ Should stats be using the manager TZ or UTC?
      * @param array $rsStatisticsData The data returned by the function
+     * @param string $timeZone Timezone sent by the client that makes the request (optional)
      *   <ul>
      *   <li><b>campaignID integer</b> The ID of the campaign
      *   <li><b>campaignName string</b> The name of the campaign
@@ -462,7 +463,7 @@ class OA_Dll_Zone extends OA_Dll
      * @return boolean True if the operation was successful and false if not.
      *
      */
-    function getZoneCampaignStatistics($zoneId, $oStartDate, $oEndDate, $localTZ, &$rsStatisticsData)
+    function getZoneCampaignStatistics($zoneId, $oStartDate, $oEndDate, $localTZ, &$rsStatisticsData, $timeZone = null)
     {
         if (!$this->checkStatisticsPermissions($zoneId)) {
             return false;
@@ -471,7 +472,7 @@ class OA_Dll_Zone extends OA_Dll
         if ($this->_validateForStatistics($zoneId, $oStartDate, $oEndDate)) {
             $dalZone = new OA_Dal_Statistics_Zone;
             $rsStatisticsData = $dalZone->getZoneCampaignStatistics($zoneId,
-                $oStartDate, $oEndDate, $localTZ);
+                $oStartDate, $oEndDate, $localTZ, $timeZone);
 
             return true;
         } else {

--- a/www/api/v2/xmlrpc/CampaignServiceImpl.php
+++ b/www/api/v2/xmlrpc/CampaignServiceImpl.php
@@ -158,17 +158,18 @@ class CampaignServiceImpl extends BaseServiceImpl
      * @param date $oStartDate
      * @param date $oEndDate
      * @param bool $localTZ
+     * @param string $timeZone
      * @param recordSet &$rsStatisticsData  return data
      *
      * @return boolean
      */
-    function getCampaignDailyStatistics($sessionId, $campaignId, $oStartDate, $oEndDate, $localTZ, &$rsStatisticsData)
+    function getCampaignDailyStatistics($sessionId, $campaignId, $oStartDate, $oEndDate, $localTZ, $timeZone, &$rsStatisticsData)
     {
         if ($this->verifySession($sessionId)) {
 
             return $this->_validateResult(
                 $this->_dllCampaign->getCampaignDailyStatistics(
-                    $campaignId, $oStartDate, $oEndDate, $localTZ, $rsStatisticsData));
+                    $campaignId, $oStartDate, $oEndDate, $localTZ, $rsStatisticsData, $timeZone));
         } else {
 
             return false;
@@ -242,17 +243,18 @@ class CampaignServiceImpl extends BaseServiceImpl
      * @param date $oStartDate
      * @param date $oEndDate
      * @param bool $localTZ
+     * @param string $timeZone
      * @param recordSet &$rsStatisticsData  return data
      *
      * @return boolean
      */
-    function getCampaignZoneStatistics($sessionId, $campaignId, $oStartDate, $oEndDate, $localTZ, &$rsStatisticsData)
+    function getCampaignZoneStatistics($sessionId, $campaignId, $oStartDate, $oEndDate, $localTZ, $timeZone, &$rsStatisticsData)
     {
         if ($this->verifySession($sessionId)) {
 
             return $this->_validateResult(
                 $this->_dllCampaign->getCampaignZoneStatistics(
-                    $campaignId, $oStartDate, $oEndDate, $localTZ, $rsStatisticsData));
+                    $campaignId, $oStartDate, $oEndDate, $localTZ, $rsStatisticsData, $timeZone));
         } else {
 
             return false;
@@ -315,18 +317,19 @@ class CampaignServiceImpl extends BaseServiceImpl
      * @param date $oStartDate
      * @param date $oEndDate
      * @param bool $localTZ
+     * @param string $timeZone
      * @param recordSet &$rsStatisticsData  return data
      *
      * @return boolean
      */
     public function getCampaignConversionStatistics(
-        $sessionId, $campaignId, $oStartDate, $oEndDate, $localTZ, &$rsStatisticsData)
+        $sessionId, $campaignId, $oStartDate, $oEndDate, $localTZ, $timeZone, &$rsStatisticsData)
     {
         if ($this->verifySession($sessionId)) {
 
             return $this->_validateResult(
                 $this->_dllCampaign->getCampaignConversionStatistics(
-                    $campaignId, $oStartDate, $oEndDate, $localTZ, $rsStatisticsData));
+                    $campaignId, $oStartDate, $oEndDate, $localTZ, $rsStatisticsData, $timeZone));
         } else {
 
             return false;

--- a/www/api/v2/xmlrpc/CampaignXmlRpcService.php
+++ b/www/api/v2/xmlrpc/CampaignXmlRpcService.php
@@ -165,14 +165,14 @@ class CampaignXmlRpcService extends BaseCampaignService
     {
         $oResponseWithError = null;
         if (!XmlRpcUtils::getScalarValues(
-                array(&$sessionId, &$campaignId, &$oStartDate, &$oEndDate, &$localTZ),
-                array(true, true, false, false, false), $oParams, $oResponseWithError)) {
+                array(&$sessionId, &$campaignId, &$oStartDate, &$oEndDate, &$localTZ, &$timeZone),
+                array(true, true, false, false, false, false), $oParams, $oResponseWithError)) {
            return $oResponseWithError;
         }
 
         $aData = null;
         if ($this->_oCampaignServiceImp->getCampaignDailyStatistics($sessionId,
-                $campaignId, $oStartDate, $oEndDate, $localTZ, $aData)) {
+                $campaignId, $oStartDate, $oEndDate, $localTZ, $timeZone, $aData)) {
 
             return XmlRpcUtils::arrayOfStructuresResponse(array('day' => 'date',
                                                         'requests' => 'integer',
@@ -275,14 +275,14 @@ class CampaignXmlRpcService extends BaseCampaignService
     {
         $oResponseWithError = null;
         if (!XmlRpcUtils::getScalarValues(
-                array(&$sessionId, &$campaignId, &$oStartDate, &$oEndDate, &$localTZ),
-                array(true, true, false, false, false), $oParams, $oResponseWithError)) {
+                array(&$sessionId, &$campaignId, &$oStartDate, &$oEndDate, &$localTZ, &$timeZone),
+                array(true, true, false, false, false, false), $oParams, $oResponseWithError)) {
            return $oResponseWithError;
         }
 
         $rsStatisticsData = null;
         if ($this->_oCampaignServiceImp->getCampaignZoneStatistics($sessionId,
-                $campaignId, $oStartDate, $oEndDate, $localTZ, $rsStatisticsData)) {
+                $campaignId, $oStartDate, $oEndDate, $localTZ, $timeZone, $rsStatisticsData)) {
 
             return XmlRpcUtils::arrayOfStructuresResponse(array('publisherId' => 'integer',
                                                         'publisherName' => 'string',
@@ -369,14 +369,14 @@ class CampaignXmlRpcService extends BaseCampaignService
     {
         $oResponseWithError = null;
         if (!XmlRpcUtils::getScalarValues(
-                array(&$sessionId, &$campaignId, &$oStartDate, &$oEndDate, &$localTZ),
-                array(true, true, false, false, false), $oParams, $oResponseWithError)) {
+                array(&$sessionId, &$campaignId, &$oStartDate, &$oEndDate, &$localTZ, &$timeZone),
+                array(true, true, false, false, false, false), $oParams, $oResponseWithError)) {
            return $oResponseWithError;
         }
 
         $rsStatisticsData = null;
         if ($this->_oCampaignServiceImp->getCampaignConversionStatistics($sessionId,
-                $campaignId, $oStartDate, $oEndDate, $localTZ, $rsStatisticsData)) {
+                $campaignId, $oStartDate, $oEndDate, $localTZ, $timeZone,$rsStatisticsData)) {
 
             return XmlRpcUtils::arrayOfStructuresResponse(
                 array('campaignID' => 'integer',

--- a/www/api/v2/xmlrpc/ZoneServiceImpl.php
+++ b/www/api/v2/xmlrpc/ZoneServiceImpl.php
@@ -214,17 +214,18 @@ class ZoneServiceImpl extends BaseServiceImpl
      * @param date $oStartDate
      * @param date $oEndDate
      * @param bool $localTZ
+     * @param string $timeZone
      * @param recordSet &$rsStatisticsData  return data
      *
      * @return boolean
      */
-    function getZoneCampaignStatistics($sessionId, $zoneId, $oStartDate, $oEndDate, $localTZ, &$rsStatisticsData)
+    function getZoneCampaignStatistics($sessionId, $zoneId, $oStartDate, $oEndDate, $localTZ, $timeZone, &$rsStatisticsData)
     {
         if ($this->verifySession($sessionId)) {
 
             return $this->_validateResult(
                 $this->_dllZone->getZoneCampaignStatistics(
-                    $zoneId, $oStartDate, $oEndDate, $localTZ, $rsStatisticsData));
+                    $zoneId, $oStartDate, $oEndDate, $localTZ,  $rsStatisticsData, $timeZone));
         } else {
 
             return false;

--- a/www/api/v2/xmlrpc/ZoneXmlRpcService.php
+++ b/www/api/v2/xmlrpc/ZoneXmlRpcService.php
@@ -229,14 +229,14 @@ class ZoneXmlRpcService extends BaseZoneService
     {
         $oResponseWithError = null;
         if (!XmlRpcUtils::getScalarValues(
-                array(&$sessionId, &$zoneId, &$oStartDate, &$oEndDate, &$localTZ),
-                array(true, true, false, false, false), $oParams, $oResponseWithError)) {
+                array(&$sessionId, &$zoneId, &$oStartDate, &$oEndDate, &$localTZ, &$timeZone),
+                array(true, true, false, false, false, false), $oParams, $oResponseWithError)) {
            return $oResponseWithError;
         }
 
         $rsStatisticsData = null;
         if ($this->_oZoneServiceImp->getZoneCampaignStatistics($sessionId,
-                $zoneId, $oStartDate, $oEndDate, $localTZ, $rsStatisticsData)) {
+                $zoneId, $oStartDate, $oEndDate, $localTZ, $timeZone, $rsStatisticsData)) {
 
             return XmlRpcUtils::arrayOfStructuresResponse(array('advertiserId' => 'integer',
                                                                 'advertiserName' => 'string',

--- a/www/api/v2/xmlrpc/index.php
+++ b/www/api/v2/xmlrpc/index.php
@@ -352,7 +352,7 @@ $dispatches = array(
     'ox.campaignDailyStatistics' => array(
         'function'  => array($fc, 'campaignDailyStatistics'),
         'signature' => array(
-            array('array', 'string', 'int', 'dateTime.iso8601', 'dateTime.iso8601', 'boolean'),
+            array('array', 'string', 'int', 'dateTime.iso8601', 'dateTime.iso8601', 'boolean', 'string'),
             array('array', 'string', 'int', 'dateTime.iso8601', 'dateTime.iso8601'),
             array('array', 'string', 'int', 'dateTime.iso8601'),
             array('array', 'string', 'int')
@@ -385,7 +385,7 @@ $dispatches = array(
     'ox.campaignZoneStatistics' => array(
         'function'  => array($fc, 'campaignZoneStatistics'),
         'signature' => array(
-            array('array', 'string', 'int', 'dateTime.iso8601', 'dateTime.iso8601', 'boolean'),
+            array('array', 'string', 'int', 'dateTime.iso8601', 'dateTime.iso8601', 'boolean', 'string'),
             array('array', 'string', 'int', 'dateTime.iso8601', 'dateTime.iso8601'),
             array('array', 'string', 'int', 'dateTime.iso8601'),
             array('array', 'string', 'int')
@@ -396,7 +396,7 @@ $dispatches = array(
     'ox.campaignConversionStatistics' => array(
         'function'  => array($fc, 'campaignConversionStatistics'),
         'signature' => array(
-            array('array', 'string', 'int', 'dateTime.iso8601', 'dateTime.iso8601', 'boolean'),
+            array('array', 'string', 'int', 'dateTime.iso8601', 'dateTime.iso8601', 'boolean', 'string'),
             array('array', 'string', 'int', 'dateTime.iso8601', 'dateTime.iso8601'),
             array('array', 'string', 'int', 'dateTime.iso8601'),
             array('array', 'string', 'int')
@@ -798,7 +798,7 @@ $dispatches = array(
     'ox.zoneCampaignStatistics' => array(
         'function'  => array($fc, 'zoneCampaignStatistics'),
         'signature' => array(
-            array('array', 'string', 'int', 'dateTime.iso8601', 'dateTime.iso8601', 'boolean'),
+            array('array', 'string', 'int', 'dateTime.iso8601', 'dateTime.iso8601', 'boolean', 'string'),
             array('array', 'string', 'int', 'dateTime.iso8601', 'dateTime.iso8601'),
             array('array', 'string', 'int', 'dateTime.iso8601'),
             array('array', 'string', 'int')


### PR DESCRIPTION
This is an example of the changes we need to achieve our requirements working with Revive Adserver as our advertisement server. 

The key is that we need to provide campaign advertisement statistics to worldwide clients respecting their time zones. 

Creating a revive user for each time zone and use it depending of our client location is not an acceptable solution for us.