### PR TITLE
#1051 - Display "Last Login Date" in user list

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -29,7 +29,8 @@ What's New in Revive Adserver 4.2.2
  New Features
  ------------
 
- * None
+ * Extended the screens for managing user access to accounts to display the most
+   recent login time of users.
 
 
  Bug Fixes

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -42,7 +42,12 @@ What's New in Revive Adserver 4.2.2
  Non-Backwards Compatible Changes
  --------------------------------
 
- * None
+ * The date and time that new user accounts are created / email address is update
+   has changed to UTC format in the database with this release. As timezone
+   information was not stored with the previous values, these cannot be safely
+   converted to UTC format. As a result, all user account creation / email address
+   update values stored before upgrading to this release may not be accurate - but
+   only by up to 13 hours.
 
 
 System Requirements

--- a/lib/OX/Extension/authentication/authentication.php
+++ b/lib/OX/Extension/authentication/authentication.php
@@ -481,7 +481,7 @@ class Plugins_Authentication extends OX_Component
     function changeEmail(&$doUsers, $emailAddress, $password)
     {
         $doUsers->email_address = $emailAddress;
-        $doUsers->email_updated = $doUsers->formatDate(new Date());
+        $doUsers->email_updated = gmdate(OA_DATETIME_FORMAT);
         return true;
     }
 

--- a/lib/RV/Admin/DateTimeFormat.php
+++ b/lib/RV/Admin/DateTimeFormat.php
@@ -56,7 +56,7 @@ class RV_Admin_DateTimeFormat
      */
     public static function formatUTCDate($sDateTime)
     {
-        // Convert the date string to a PEAR Date object in the user
+        // Convert the date/time string to a PEAR Date object in the user
         // locale's timezone
         $oDate = RV_Admin_DateTimeFormat::_convertUTCtoUserTZ($sDateTime);
         // Obtain the globally set $date_format value from the user's locale
@@ -79,9 +79,69 @@ class RV_Admin_DateTimeFormat
      */
     public static function formatUTCTime($sDateTime)
     {
-        // Convert the time string to a PEAR Date object in the user
+        // Convert the time date/string to a PEAR Date object in the user
         // locale's timezone
         $oTime = RV_Admin_DateTimeFormat::_convertUTCtoUserTZ($sDateTime);
+        // Obtain the globally set $time_format value from the user's locale
+        // which defines how the time output string should be formatted
+        global $time_format;
+        // Return the converted PEAR Date object in the appropriate locale
+        // format for time values
+        return $oTime->format("$time_format");
+    }
+
+    /**
+     * A method that takes a date/time string and formats it using the user's
+     * locale information - i.e. using the appropriate date/time representation.
+     *
+     * @param string dateTime The date/time to be formatted, in a string format
+     * @return string The date/time in the user's locale format
+     */
+    public static function formatDateTime($sDateTime)
+    {
+        // Convert the date/time string to a PEAR Date object
+        $oDateTime = new Date($sDateTime);
+        // Obtain the globally set $date_format and $time_format values
+        // from the user's locale which defines how the date/time output
+        // string should be formatted
+        global $date_format, $time_format;
+        // Return the converted PEAR Date object in the appropriate locale
+        // format for date/time values
+        return $oDateTime->format("$date_format $time_format");
+    }
+
+    /**
+     * A method that takes a date/time string and formats it using the user's
+     * locale information - i.e. using the appropriate date representation.
+     *
+     * @param string dateTime The date/time to be formatted, in a string format
+     * @return string The date/time formatted as a date only, in the user's
+     *                locale format
+     */
+    public static function formatDate($sDateTime)
+    {
+        // Convert the date/time string to a PEAR Date object
+        $oDate = new Date($sDateTime);
+        // Obtain the globally set $date_format value from the user's locale
+        // which defines how the date output string should be formatted
+        global $date_format;
+        // Return the converted PEAR Date object in the appropriate locale
+        // format for date values
+        return $oDate->format("$date_format");
+    }
+
+    /**
+     * A method that takes a date/time string and formats it using the user's
+     * locale information - i.e. using the appropriate time representation.
+     *
+     * @param string dateTime The date/time to be formatted, in a string format
+     * @return string The date/time formatted as a time only, in the user's
+     *                locale format
+     */
+    public static function formatTime($sDateTime)
+    {
+        // Convert the date/time string to a PEAR Date object
+        $oTime = new Date($sDateTime);
         // Obtain the globally set $time_format value from the user's locale
         // which defines how the time output string should be formatted
         global $time_format;

--- a/lib/RV/Admin/DateTimeFormat.php
+++ b/lib/RV/Admin/DateTimeFormat.php
@@ -35,13 +35,8 @@ class RV_Admin_DateTimeFormat
         // Convert the date/time string to a PEAR Date object in the user
         // locale's timezone
         $oDateTime = RV_Admin_DateTimeFormat::_convertUTCtoUserTZ($sDateTime);
-        // Obtain the globally set $date_format and $time_format values
-        // from the user's locale which defines how the date/time output
-        // string should be formatted
-        global $date_format, $time_format;
-        // Return the converted PEAR Date object in the appropriate locale
-        // format for date/time values
-        return $oDateTime->format("$date_format $time_format");
+        // Return the date/time using the user's locale information
+        return RV_Admin_DateTimeFormat::_formatLocalDateTime($oDateTime);
     }
 
     /**
@@ -58,13 +53,9 @@ class RV_Admin_DateTimeFormat
     {
         // Convert the date/time string to a PEAR Date object in the user
         // locale's timezone
-        $oDate = RV_Admin_DateTimeFormat::_convertUTCtoUserTZ($sDateTime);
-        // Obtain the globally set $date_format value from the user's locale
-        // which defines how the date output string should be formatted
-        global $date_format;
-        // Return the converted PEAR Date object in the appropriate locale
-        // format for date values
-        return $oDate->format("$date_format");
+        $oDateTime = RV_Admin_DateTimeFormat::_convertUTCtoUserTZ($sDateTime);
+        // Return the date only using the user's locale information
+        return RV_Admin_DateTimeFormat::_formatLocalDate($oDateTime);
     }
 
     /**
@@ -79,85 +70,71 @@ class RV_Admin_DateTimeFormat
      */
     public static function formatUTCTime($sDateTime)
     {
-        // Convert the time date/string to a PEAR Date object in the user
+        // Convert the date/time string to a PEAR Date object in the user
         // locale's timezone
-        $oTime = RV_Admin_DateTimeFormat::_convertUTCtoUserTZ($sDateTime);
-        // Obtain the globally set $time_format value from the user's locale
-        // which defines how the time output string should be formatted
-        global $time_format;
-        // Return the converted PEAR Date object in the appropriate locale
-        // format for time values
-        return $oTime->format("$time_format");
+        $oDateTime = RV_Admin_DateTimeFormat::_convertUTCtoUserTZ($sDateTime);
+        // Return the time only using the user's locale information
+        return RV_Admin_DateTimeFormat::_formatLocalTime($oDateTime);
     }
 
     /**
-     * A method that takes a date/time string and formats it using the user's
-     * locale information - i.e. using the appropriate date/time representation.
+     * A method that takes a local timezone date/time string and formats it
+     * using the user's locale information - i.e. using the appropriate
+     * date/time representation.
      *
      * @param string dateTime The date/time to be formatted, in a string format
      * @return string The date/time in the user's locale format
      */
-    public static function formatDateTime($sDateTime)
+    public static function formatLocalDateTime($sDateTime)
     {
         // Convert the date/time string to a PEAR Date object
         $oDateTime = new Date($sDateTime);
-        // Obtain the globally set $date_format and $time_format values
-        // from the user's locale which defines how the date/time output
-        // string should be formatted
-        global $date_format, $time_format;
-        // Return the converted PEAR Date object in the appropriate locale
-        // format for date/time values
-        return $oDateTime->format("$date_format $time_format");
+        // Return the date/time using the user's locale information
+        return RV_Admin_DateTimeFormat::_formatLocalDateTime($oDateTime);
     }
 
     /**
-     * A method that takes a date/time string and formats it using the user's
-     * locale information - i.e. using the appropriate date representation.
+     * A method that takes a local timezone date/time string and formats it
+     * using the user's locale information - i.e. using the appropriate
+     * date representation.
      *
      * @param string dateTime The date/time to be formatted, in a string format
      * @return string The date/time formatted as a date only, in the user's
      *                locale format
      */
-    public static function formatDate($sDateTime)
+    public static function formatLocalDate($sDateTime)
     {
         // Convert the date/time string to a PEAR Date object
-        $oDate = new Date($sDateTime);
-        // Obtain the globally set $date_format value from the user's locale
-        // which defines how the date output string should be formatted
-        global $date_format;
-        // Return the converted PEAR Date object in the appropriate locale
-        // format for date values
-        return $oDate->format("$date_format");
+        $oDateTime = new Date($sDateTime);
+        // Return the date only using the user's locale information
+        return RV_Admin_DateTimeFormat::_formatLocalDate($oDateTime);
     }
 
     /**
-     * A method that takes a date/time string and formats it using the user's
-     * locale information - i.e. using the appropriate time representation.
+     * A method that takes a local timezone date/time string and formats it
+     * using the user's locale information - i.e. using the appropriate
+     * time representation.
      *
      * @param string dateTime The date/time to be formatted, in a string format
      * @return string The date/time formatted as a time only, in the user's
      *                locale format
      */
-    public static function formatTime($sDateTime)
+    public static function formatLocalTime($sDateTime)
     {
         // Convert the date/time string to a PEAR Date object
-        $oTime = new Date($sDateTime);
-        // Obtain the globally set $time_format value from the user's locale
-        // which defines how the time output string should be formatted
-        global $time_format;
-        // Return the converted PEAR Date object in the appropriate locale
-        // format for time values
-        return $oTime->format("$time_format");
+        $oDateTime = new Date($sDateTime);
+        // Return the time only using the user's locale information
+        return RV_Admin_DateTimeFormat::_formatLocalTime($oDateTime);
     }
 
     /**
      * A private method that takes a UTC date, time or date/time string
      * and converts it into a PEAR Date object, converting the date, time or
-     * date/time into the user locale's timezone.
+     * date/time into the user's local timezone.
      *
-     * @param type $sDateTime The date, time or date/time , in a string format
+     * @param string $sDateTime The date, time or date/time , in a string format
      * @return PEAR::Date The date, time or date/time as a PEAR Date object,
-     *                    in the user locale's timezone
+     *                    in the user's local timezone
      */
     private static function _convertUTCtoUserTZ($sDateTime)
     {
@@ -170,10 +147,52 @@ class RV_Admin_DateTimeFormat
         // without actually changing the date & time values
         $oDateTime->setTZbyID('UTC');
         // Convert the PEAR Date object into the original timezone, but with
-        // the required changeing of the date & time values
+        // the required changing of the date & time values
         $oDateTime->convertTZ($oTz);
         // Return the PEAR Date object
         return $oDateTime;
+    }
+
+    /**
+     * A private method that takes a PEAR Date object in the user's local
+     * timezone, and returns a date/time string, formatted according to the
+     * user's locale format.
+     *
+     * @param PEAR::Date $oDateTime The date/time to format.
+     * @return string The date and time, formatted according to the user's
+     *                locale format.
+     */
+    private static function _formatLocalDateTime($oDateTime)
+    {
+        return $oDateTime->format("{$GLOBALS['date_format']} {$GLOBALS['time_format']}");
+    }
+
+    /**
+     * A private method that takes a PEAR Date object in the user's local
+     * timezone, and returns a date string, formatted according to the
+     * user's locale format.
+     *
+     * @param PEAR::Date $oDateTime The date/time to format.
+     * @return string The date only, formatted according to the user's
+     *                locale format.
+     */
+    private static function _formatLocalDate($oDateTime)
+    {
+        return $oDateTime->format("{$GLOBALS['date_format']}");
+    }
+
+    /**
+     * A private method that takes a PEAR Date object in the user's local
+     * timezone, and returns a time string, formatted according to the
+     * user's locale format.
+     *
+     * @param PEAR::Date $oDateTime The date/time to format.
+     * @return string The time only, formatted according to the user's
+     *                locale format.
+     */
+    private static function _formatLocalTime($oDateTime)
+    {
+        return $oDateTime->format("{$GLOBALS['time_format']}");
     }
 
 }

--- a/lib/max/Dal/DataObjects/Users.php
+++ b/lib/max/Dal/DataObjects/Users.php
@@ -60,14 +60,15 @@ class DataObjects_Users extends DB_DataObjectCommon
      */
     function insert()
     {
+        $now = gmdate(OA_DATETIME_FORMAT);
         if (isset($this->username)) {
             $this->username = strtolower($this->username);
         }
         if (empty($this->date_created)) {
-            $this->date_created = $this->formatDate(new Date());
+            $this->date_created = $now;
         }
         if (empty($this->email_updated)) {
-            $this->email_updated = $this->formatDate(new Date());
+            $this->email_updated = $now;
         }
         return parent::insert();
     }

--- a/lib/templates/admin/user-access.html
+++ b/lib/templates/admin/user-access.html
@@ -25,11 +25,8 @@
       <td style="width: 25%">{t str=EMail}</td>
     {/if}
       <td style="width: 20%">{t str=ContactName}</td>
-    {if $sso}
       <td style="width: 15%">{t str=LastLoggedIn}</td>
-    {else}
       <td style="width: 15%">{t str=DateLinked}</td>
-    {/if}
       <td style="width: 25%"></td>
     </tr>
 
@@ -50,11 +47,8 @@
         <td><a href="{$editPage}?userid={$user.user_id}{if $entityIdName}&amp;{$entityIdName}={$entityIdValue}{/if}">{$user.email_address|escape}</a></td>
       {/if}
         <td>{$user.contact_name|escape}</td>
-      {if $sso}
         <td>{$user.date_last_login}</td>
-      {else}
         <td>{$user.date_created}</td>
-      {/if}
         <td class="last">
           <a href="{$editPage}?userid={$user.user_id}{if $entityIdName}&amp;{$entityIdName}={$entityIdValue}{/if}" class="permissions" style="padding-right: 10px">{t str=Permissions}</a>
           <a href="{$unlinkPage}?userid={$user.user_id}{if $entityIdName}&amp;{$entityIdName}={$entityIdValue}{/if}&amp;{rv_add_session_token}" class="unlink{if $user.toDelete} unlink-last{else} unlink-normal{/if}">{t str=Remove}</a>

--- a/www/admin/advertiser-access.php
+++ b/www/admin/advertiser-access.php
@@ -81,10 +81,9 @@ foreach ($aUsers as $key => $aValue) {
     // Date of last login is stored in UTC, so needs to be converted into the current user's
     // local timezone, and then converted into the user's desired date/time format
     $aUsers[$key]['date_last_login'] = RV_Admin_DateTimeFormat::formatUTCDateTime($aValue['date_last_login']);
-    // Date created/linked is stored in the local user's timezone at time of creation/linking,
-    // so only conversion into the user's desired date format is needed - date only is used to
-    // indicate that this is not a 100% accurate value, just an indication of the value
-    $aUsers[$key]['date_created'] = RV_Admin_DateTimeFormat::formatLocalDate($aValue['date_created']);
+    // Date created/linked is stored in UTC, so needs to be converted into the current user's
+    // local timezone, and then converted into the user's desired date/time format
+    $aUsers[$key]['date_created'] = RV_Admin_DateTimeFormat::formatUTCDateTime($aValue['date_created']);
 }
 $oTpl->assign('users', array('aUsers' => $aUsers));
 $oTpl->display();

--- a/www/admin/advertiser-access.php
+++ b/www/admin/advertiser-access.php
@@ -77,14 +77,13 @@ $oTpl->assign('unlinkPage', 'advertiser-user-unlink.php');
 
 $doUsers = OA_Dal::factoryDO('users');
 $aUsers =  $doUsers->getAccountUsersByEntity('clients', $clientid);
-$datetime_format = $date_format . " " . $time_format;
 foreach ($aUsers as $key => $aValue) {
     // Date of last login is stored in UTC, so needs to be converted into the current user's
     // local timezone, and then converted into the user's desired date/time format
     $aUsers[$key]['date_last_login'] = RV_Admin_DateTimeFormat::formatUTCDateTime($aValue['date_last_login']);
     // Date created/linked is stored in the local user's timezone at time of creation/linking,
     // so only conversion into the user's desired date/time format is needed
-    $aUsers[$key]['date_created'] = RV_Admin_DateTimeFormat::formatDateTime($aValue['date_created']);
+    $aUsers[$key]['date_created'] = RV_Admin_DateTimeFormat::formatLocalDateTime($aValue['date_created']);
 }
 $oTpl->assign('users', array('aUsers' => $aUsers));
 $oTpl->display();

--- a/www/admin/advertiser-access.php
+++ b/www/admin/advertiser-access.php
@@ -14,21 +14,21 @@
 require_once '../../init.php';
 
 // Required files
-require_once MAX_PATH . '/lib/OA/Dal.php';
-require_once MAX_PATH . '/lib/RV/Admin/Languages.php';
-require_once MAX_PATH . '/www/admin/config.php';
-require_once MAX_PATH . '/www/admin/lib-statistics.inc.php';
-require_once MAX_PATH . '/lib/OA/Session.php';
-require_once MAX_PATH . '/lib/OA/Admin/Menu.php';
-require_once MAX_PATH . '/lib/max/other/html.php';
-require_once MAX_PATH . '/lib/OA/Auth.php';
-require_once MAX_PATH . '/lib/OA/Admin/UI/UserAccess.php';
+require_once RV_PATH . '/lib/OA/Dal.php';
+require_once RV_PATH . '/lib/RV/Admin/Languages.php';
+require_once RV_PATH . '/lib/RV/Admin/DateTimeFormat.php';
+require_once RV_PATH . '/www/admin/config.php';
+require_once RV_PATH . '/www/admin/lib-statistics.inc.php';
+require_once RV_PATH . '/lib/OA/Session.php';
+require_once RV_PATH . '/lib/OA/Admin/Menu.php';
+require_once RV_PATH . '/lib/max/other/html.php';
+require_once RV_PATH . '/lib/OA/Auth.php';
+require_once RV_PATH . '/lib/OA/Admin/UI/UserAccess.php';
 
 // Security check
 OA_Permission::enforceAccount(OA_ACCOUNT_MANAGER, OA_ACCOUNT_ADVERTISER);
 OA_Permission::enforceAccountPermission(OA_ACCOUNT_ADVERTISER, OA_PERM_SUPER_ACCOUNT);
 OA_Permission::enforceAccessToObject('clients', $clientid);
-
 
 /*-------------------------------------------------------*/
 /* Store preferences									 */
@@ -76,7 +76,17 @@ $oTpl->assign('editPage', 'advertiser-user.php');
 $oTpl->assign('unlinkPage', 'advertiser-user-unlink.php');
 
 $doUsers = OA_Dal::factoryDO('users');
-$oTpl->assign('users', array('aUsers' => $doUsers->getAccountUsersByEntity('clients', $clientid)));
+$aUsers =  $doUsers->getAccountUsersByEntity('clients', $clientid);
+$datetime_format = $date_format . " " . $time_format;
+foreach ($aUsers as $key => $aValue) {
+    // Date of last login is stored in UTC, so needs to be converted into the current user's
+    // local timezone, and then converted into the user's desired date/time format
+    $aUsers[$key]['date_last_login'] = RV_Admin_DateTimeFormat::formatUTCDateTime($aValue['date_last_login']);
+    // Date created/linked is stored in the local user's timezone at time of creation/linking,
+    // so only conversion into the user's desired date/time format is needed
+    $aUsers[$key]['date_created'] = RV_Admin_DateTimeFormat::formatDateTime($aValue['date_created']);
+}
+$oTpl->assign('users', array('aUsers' => $aUsers));
 $oTpl->display();
 
 /*-------------------------------------------------------*/
@@ -89,6 +99,5 @@ function addPageTools($clientid)
 {
     addPageLinkTool($GLOBALS["strLinkUser_Key"], "advertiser-user-start.php?clientid=$clientid", "iconAdvertiserAdd", $GLOBALS["keyLinkUser"] );
 }
-
 
 ?>

--- a/www/admin/advertiser-access.php
+++ b/www/admin/advertiser-access.php
@@ -82,8 +82,9 @@ foreach ($aUsers as $key => $aValue) {
     // local timezone, and then converted into the user's desired date/time format
     $aUsers[$key]['date_last_login'] = RV_Admin_DateTimeFormat::formatUTCDateTime($aValue['date_last_login']);
     // Date created/linked is stored in the local user's timezone at time of creation/linking,
-    // so only conversion into the user's desired date/time format is needed
-    $aUsers[$key]['date_created'] = RV_Admin_DateTimeFormat::formatLocalDateTime($aValue['date_created']);
+    // so only conversion into the user's desired date format is needed - date only is used to
+    // indicate that this is not a 100% accurate value, just an indication of the value
+    $aUsers[$key]['date_created'] = RV_Admin_DateTimeFormat::formatLocalDate($aValue['date_created']);
 }
 $oTpl->assign('users', array('aUsers' => $aUsers));
 $oTpl->display();


### PR DESCRIPTION
Extended the screens for managing user access to accounts to display the most recent login time of users. Includes an update to the RV_Admin_DateTimeFormat class to support formatting of Dates and Times that are already in the user's locale timezone (i.e. not in UTC).