### PR TITLE
Properly deal with multiple cookies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,7 @@
         "figdice/asseteer": "dev-master",
         "tinymce/tinymce": "^4.6",
         "wikimedia/composer-merge-plugin": "^1.4",
-        "guzzlehttp/guzzle": "^6.3",
-        "symfony/http-foundation": "^3.4"
+        "guzzlehttp/guzzle": "^6.3"
     },
     "require-dev": {
         "symfony/finder": "^3.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ac08bcc4e6c02343f64fe3dfb626c8ab",
+    "content-hash": "222ddd649bd99711fcef452415449140",
     "packages": [
         {
             "name": "figdice/asseteer",
@@ -487,51 +487,6 @@
             "time": "2019-01-04T19:55:56+00:00"
         },
         {
-            "name": "paragonie/random_compat",
-            "version": "v9.99.99",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95",
-                "reference": "84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "4.*|5.*",
-                "vimeo/psalm": "^1"
-            },
-            "suggest": {
-                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
-            },
-            "type": "library",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Paragon Initiative Enterprises",
-                    "email": "security@paragonie.com",
-                    "homepage": "https://paragonie.com"
-                }
-            ],
-            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
-            "keywords": [
-                "csprng",
-                "polyfill",
-                "pseudorandom",
-                "random"
-            ],
-            "time": "2018-07-02T15:55:56+00:00"
-        },
-        {
             "name": "psr/container",
             "version": "1.0.0",
             "source": {
@@ -905,60 +860,6 @@
             "time": "2019-02-04T21:34:32+00:00"
         },
         {
-            "name": "symfony/http-foundation",
-            "version": "v3.4.36",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "d2d0cfe8e319d9df44c4cca570710fcf221d4593"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/d2d0cfe8e319d9df44c4cca570710fcf221d4593",
-                "reference": "d2d0cfe8e319d9df44c4cca570710fcf221d4593",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/polyfill-mbstring": "~1.1",
-                "symfony/polyfill-php70": "~1.6"
-            },
-            "require-dev": {
-                "symfony/expression-language": "~2.8|~3.0|~4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\HttpFoundation\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony HttpFoundation Component",
-            "homepage": "https://symfony.com",
-            "time": "2019-11-28T12:52:59+00:00"
-        },
-        {
             "name": "symfony/polyfill-ctype",
             "version": "v1.11.0",
             "source": {
@@ -1013,124 +914,6 @@
                 "ctype",
                 "polyfill",
                 "portable"
-            ],
-            "time": "2019-02-06T07:57:58+00:00"
-        },
-        {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.11.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "fe5e94c604826c35a32fa832f35bd036b6799609"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/fe5e94c604826c35a32fa832f35bd036b6799609",
-                "reference": "fe5e94c604826c35a32fa832f35bd036b6799609",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "suggest": {
-                "ext-mbstring": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.11-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for the Mbstring extension",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "mbstring",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "time": "2019-02-06T07:57:58+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php70",
-            "version": "v1.11.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php70.git",
-                "reference": "bc4858fb611bda58719124ca079baff854149c89"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/bc4858fb611bda58719124ca079baff854149c89",
-                "reference": "bc4858fb611bda58719124ca079baff854149c89",
-                "shasum": ""
-            },
-            "require": {
-                "paragonie/random_compat": "~1.0|~2.0|~9.99",
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.11-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php70\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ],
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 7.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
             ],
             "time": "2019-02-06T07:57:58+00:00"
         },
@@ -1554,6 +1337,51 @@
             "time": "2019-06-01T10:32:12+00:00"
         },
         {
+            "name": "paragonie/random_compat",
+            "version": "v9.99.99",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95",
+                "reference": "84b4dfb120c6f9b4ff7b3685f9b8f1aa365a0c95",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*",
+                "vimeo/psalm": "^1"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "polyfill",
+                "pseudorandom",
+                "random"
+            ],
+            "time": "2018-07-02T15:55:56+00:00"
+        },
+        {
             "name": "php-cs-fixer/diff",
             "version": "v1.3.0",
             "source": {
@@ -1944,6 +1772,124 @@
                 "options"
             ],
             "time": "2019-04-10T16:00:48+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.13.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "7b4aab9743c30be783b73de055d24a39cf4b954f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/7b4aab9743c30be783b73de055d24a39cf4b954f",
+                "reference": "7b4aab9743c30be783b73de055d24a39cf4b954f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.13-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2019-11-27T14:18:11+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php70",
+            "version": "v1.13.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php70.git",
+                "reference": "af23c7bb26a73b850840823662dda371484926c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/af23c7bb26a73b850840823662dda371484926c4",
+                "reference": "af23c7bb26a73b850840823662dda371484926c4",
+                "shasum": ""
+            },
+            "require": {
+                "paragonie/random_compat": "~1.0|~2.0|~9.99",
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.13-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php70\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2019-11-27T13:56:44+00:00"
         },
         {
             "name": "symfony/polyfill-php72",

--- a/www/admin/lib-sessions.inc.php
+++ b/www/admin/lib-sessions.inc.php
@@ -65,7 +65,7 @@ function phpAds_SessionSetAdminCookie($name, $value)
 {
     $conf = $GLOBALS['_MAX']['CONF'];
 
-    $cookie = new \Symfony\Component\HttpFoundation\Cookie(
+    MAX_cookieClientCookieSet(
         $name,
         $value,
         0,
@@ -73,11 +73,8 @@ function phpAds_SessionSetAdminCookie($name, $value)
         empty($_SERVER['HTTP_HOST']) ? null : preg_replace('#:\d+$#', '', $_SERVER['HTTP_HOST']),
         !empty($conf['openads']['requireSSL']),
         true,
-        false,
         'strict'
     );
-
-    MAX_header("Set-Cookie: {$cookie}");
 }
 
 /*-------------------------------------------------------*/

--- a/www/delivery/ac.php
+++ b/www/delivery/ac.php
@@ -437,7 +437,7 @@ if ($block > 0 || $setBlock) {
 MAX_cookieAdd("_{$conf['var']['block' . $type]}[{$id}]", MAX_commonGetTimeNow(), _getTimeThirtyDaysFromNow());
 }
 }
-function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null)
+function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null, $secure = null, $httpOnly = false, $sameSite = 'none')
 {
  if (isset($GLOBALS['_OA']['invocationType']) && $GLOBALS['_OA']['invocationType'] == 'xmlrpc') {
 if (!isset($GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'])) {
@@ -445,10 +445,19 @@ $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'] = array();
 }
 $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'][$name] = array($value, $expire);
 } else {
-$secure = !empty($GLOBALS['_MAX']['SSL_REQUEST']);
-$samesite = $secure ? 'none' : 'lax';
-$cookie = new \Symfony\Component\HttpFoundation\Cookie($name, $value, $expire, $path, $domain, $secure, false, false, $samesite);
-MAX_header("Set-Cookie: {$cookie}");
+$secure = $secure ?? !empty($GLOBALS['_MAX']['SSL_REQUEST']);
+if (PHP_VERSION_ID < 70300) {
+@setcookie($name, $value, $expire, $path.'; samesite='.$sameSite, $domain, $secure, $httpOnly);
+} else {
+@setcookie($name, $value, [
+'expire' => $expire,
+'path' => $path,
+'domain' => $domain,
+'secure' => $secure,
+'httponly' => $httpOnly,
+'samesite' => $sameSite,
+]);
+}
 }
 }
 function MAX_cookieClientCookieUnset($name)

--- a/www/delivery/afr.php
+++ b/www/delivery/afr.php
@@ -437,7 +437,7 @@ if ($block > 0 || $setBlock) {
 MAX_cookieAdd("_{$conf['var']['block' . $type]}[{$id}]", MAX_commonGetTimeNow(), _getTimeThirtyDaysFromNow());
 }
 }
-function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null)
+function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null, $secure = null, $httpOnly = false, $sameSite = 'none')
 {
  if (isset($GLOBALS['_OA']['invocationType']) && $GLOBALS['_OA']['invocationType'] == 'xmlrpc') {
 if (!isset($GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'])) {
@@ -445,10 +445,19 @@ $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'] = array();
 }
 $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'][$name] = array($value, $expire);
 } else {
-$secure = !empty($GLOBALS['_MAX']['SSL_REQUEST']);
-$samesite = $secure ? 'none' : 'lax';
-$cookie = new \Symfony\Component\HttpFoundation\Cookie($name, $value, $expire, $path, $domain, $secure, false, false, $samesite);
-MAX_header("Set-Cookie: {$cookie}");
+$secure = $secure ?? !empty($GLOBALS['_MAX']['SSL_REQUEST']);
+if (PHP_VERSION_ID < 70300) {
+@setcookie($name, $value, $expire, $path.'; samesite='.$sameSite, $domain, $secure, $httpOnly);
+} else {
+@setcookie($name, $value, [
+'expire' => $expire,
+'path' => $path,
+'domain' => $domain,
+'secure' => $secure,
+'httponly' => $httpOnly,
+'samesite' => $sameSite,
+]);
+}
 }
 }
 function MAX_cookieClientCookieUnset($name)

--- a/www/delivery/ai.php
+++ b/www/delivery/ai.php
@@ -437,7 +437,7 @@ if ($block > 0 || $setBlock) {
 MAX_cookieAdd("_{$conf['var']['block' . $type]}[{$id}]", MAX_commonGetTimeNow(), _getTimeThirtyDaysFromNow());
 }
 }
-function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null)
+function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null, $secure = null, $httpOnly = false, $sameSite = 'none')
 {
  if (isset($GLOBALS['_OA']['invocationType']) && $GLOBALS['_OA']['invocationType'] == 'xmlrpc') {
 if (!isset($GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'])) {
@@ -445,10 +445,19 @@ $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'] = array();
 }
 $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'][$name] = array($value, $expire);
 } else {
-$secure = !empty($GLOBALS['_MAX']['SSL_REQUEST']);
-$samesite = $secure ? 'none' : 'lax';
-$cookie = new \Symfony\Component\HttpFoundation\Cookie($name, $value, $expire, $path, $domain, $secure, false, false, $samesite);
-MAX_header("Set-Cookie: {$cookie}");
+$secure = $secure ?? !empty($GLOBALS['_MAX']['SSL_REQUEST']);
+if (PHP_VERSION_ID < 70300) {
+@setcookie($name, $value, $expire, $path.'; samesite='.$sameSite, $domain, $secure, $httpOnly);
+} else {
+@setcookie($name, $value, [
+'expire' => $expire,
+'path' => $path,
+'domain' => $domain,
+'secure' => $secure,
+'httponly' => $httpOnly,
+'samesite' => $sameSite,
+]);
+}
 }
 }
 function MAX_cookieClientCookieUnset($name)

--- a/www/delivery/ajs.php
+++ b/www/delivery/ajs.php
@@ -437,7 +437,7 @@ if ($block > 0 || $setBlock) {
 MAX_cookieAdd("_{$conf['var']['block' . $type]}[{$id}]", MAX_commonGetTimeNow(), _getTimeThirtyDaysFromNow());
 }
 }
-function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null)
+function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null, $secure = null, $httpOnly = false, $sameSite = 'none')
 {
  if (isset($GLOBALS['_OA']['invocationType']) && $GLOBALS['_OA']['invocationType'] == 'xmlrpc') {
 if (!isset($GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'])) {
@@ -445,10 +445,19 @@ $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'] = array();
 }
 $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'][$name] = array($value, $expire);
 } else {
-$secure = !empty($GLOBALS['_MAX']['SSL_REQUEST']);
-$samesite = $secure ? 'none' : 'lax';
-$cookie = new \Symfony\Component\HttpFoundation\Cookie($name, $value, $expire, $path, $domain, $secure, false, false, $samesite);
-MAX_header("Set-Cookie: {$cookie}");
+$secure = $secure ?? !empty($GLOBALS['_MAX']['SSL_REQUEST']);
+if (PHP_VERSION_ID < 70300) {
+@setcookie($name, $value, $expire, $path.'; samesite='.$sameSite, $domain, $secure, $httpOnly);
+} else {
+@setcookie($name, $value, [
+'expire' => $expire,
+'path' => $path,
+'domain' => $domain,
+'secure' => $secure,
+'httponly' => $httpOnly,
+'samesite' => $sameSite,
+]);
+}
 }
 }
 function MAX_cookieClientCookieUnset($name)

--- a/www/delivery/al.php
+++ b/www/delivery/al.php
@@ -437,7 +437,7 @@ if ($block > 0 || $setBlock) {
 MAX_cookieAdd("_{$conf['var']['block' . $type]}[{$id}]", MAX_commonGetTimeNow(), _getTimeThirtyDaysFromNow());
 }
 }
-function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null)
+function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null, $secure = null, $httpOnly = false, $sameSite = 'none')
 {
  if (isset($GLOBALS['_OA']['invocationType']) && $GLOBALS['_OA']['invocationType'] == 'xmlrpc') {
 if (!isset($GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'])) {
@@ -445,10 +445,19 @@ $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'] = array();
 }
 $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'][$name] = array($value, $expire);
 } else {
-$secure = !empty($GLOBALS['_MAX']['SSL_REQUEST']);
-$samesite = $secure ? 'none' : 'lax';
-$cookie = new \Symfony\Component\HttpFoundation\Cookie($name, $value, $expire, $path, $domain, $secure, false, false, $samesite);
-MAX_header("Set-Cookie: {$cookie}");
+$secure = $secure ?? !empty($GLOBALS['_MAX']['SSL_REQUEST']);
+if (PHP_VERSION_ID < 70300) {
+@setcookie($name, $value, $expire, $path.'; samesite='.$sameSite, $domain, $secure, $httpOnly);
+} else {
+@setcookie($name, $value, [
+'expire' => $expire,
+'path' => $path,
+'domain' => $domain,
+'secure' => $secure,
+'httponly' => $httpOnly,
+'samesite' => $sameSite,
+]);
+}
 }
 }
 function MAX_cookieClientCookieUnset($name)

--- a/www/delivery/alocal.php
+++ b/www/delivery/alocal.php
@@ -437,7 +437,7 @@ if ($block > 0 || $setBlock) {
 MAX_cookieAdd("_{$conf['var']['block' . $type]}[{$id}]", MAX_commonGetTimeNow(), _getTimeThirtyDaysFromNow());
 }
 }
-function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null)
+function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null, $secure = null, $httpOnly = false, $sameSite = 'none')
 {
  if (isset($GLOBALS['_OA']['invocationType']) && $GLOBALS['_OA']['invocationType'] == 'xmlrpc') {
 if (!isset($GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'])) {
@@ -445,10 +445,19 @@ $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'] = array();
 }
 $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'][$name] = array($value, $expire);
 } else {
-$secure = !empty($GLOBALS['_MAX']['SSL_REQUEST']);
-$samesite = $secure ? 'none' : 'lax';
-$cookie = new \Symfony\Component\HttpFoundation\Cookie($name, $value, $expire, $path, $domain, $secure, false, false, $samesite);
-MAX_header("Set-Cookie: {$cookie}");
+$secure = $secure ?? !empty($GLOBALS['_MAX']['SSL_REQUEST']);
+if (PHP_VERSION_ID < 70300) {
+@setcookie($name, $value, $expire, $path.'; samesite='.$sameSite, $domain, $secure, $httpOnly);
+} else {
+@setcookie($name, $value, [
+'expire' => $expire,
+'path' => $path,
+'domain' => $domain,
+'secure' => $secure,
+'httponly' => $httpOnly,
+'samesite' => $sameSite,
+]);
+}
 }
 }
 function MAX_cookieClientCookieUnset($name)

--- a/www/delivery/apu.php
+++ b/www/delivery/apu.php
@@ -437,7 +437,7 @@ if ($block > 0 || $setBlock) {
 MAX_cookieAdd("_{$conf['var']['block' . $type]}[{$id}]", MAX_commonGetTimeNow(), _getTimeThirtyDaysFromNow());
 }
 }
-function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null)
+function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null, $secure = null, $httpOnly = false, $sameSite = 'none')
 {
  if (isset($GLOBALS['_OA']['invocationType']) && $GLOBALS['_OA']['invocationType'] == 'xmlrpc') {
 if (!isset($GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'])) {
@@ -445,10 +445,19 @@ $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'] = array();
 }
 $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'][$name] = array($value, $expire);
 } else {
-$secure = !empty($GLOBALS['_MAX']['SSL_REQUEST']);
-$samesite = $secure ? 'none' : 'lax';
-$cookie = new \Symfony\Component\HttpFoundation\Cookie($name, $value, $expire, $path, $domain, $secure, false, false, $samesite);
-MAX_header("Set-Cookie: {$cookie}");
+$secure = $secure ?? !empty($GLOBALS['_MAX']['SSL_REQUEST']);
+if (PHP_VERSION_ID < 70300) {
+@setcookie($name, $value, $expire, $path.'; samesite='.$sameSite, $domain, $secure, $httpOnly);
+} else {
+@setcookie($name, $value, [
+'expire' => $expire,
+'path' => $path,
+'domain' => $domain,
+'secure' => $secure,
+'httponly' => $httpOnly,
+'samesite' => $sameSite,
+]);
+}
 }
 }
 function MAX_cookieClientCookieUnset($name)

--- a/www/delivery/asyncspc.php
+++ b/www/delivery/asyncspc.php
@@ -437,7 +437,7 @@ if ($block > 0 || $setBlock) {
 MAX_cookieAdd("_{$conf['var']['block' . $type]}[{$id}]", MAX_commonGetTimeNow(), _getTimeThirtyDaysFromNow());
 }
 }
-function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null)
+function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null, $secure = null, $httpOnly = false, $sameSite = 'none')
 {
  if (isset($GLOBALS['_OA']['invocationType']) && $GLOBALS['_OA']['invocationType'] == 'xmlrpc') {
 if (!isset($GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'])) {
@@ -445,10 +445,19 @@ $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'] = array();
 }
 $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'][$name] = array($value, $expire);
 } else {
-$secure = !empty($GLOBALS['_MAX']['SSL_REQUEST']);
-$samesite = $secure ? 'none' : 'lax';
-$cookie = new \Symfony\Component\HttpFoundation\Cookie($name, $value, $expire, $path, $domain, $secure, false, false, $samesite);
-MAX_header("Set-Cookie: {$cookie}");
+$secure = $secure ?? !empty($GLOBALS['_MAX']['SSL_REQUEST']);
+if (PHP_VERSION_ID < 70300) {
+@setcookie($name, $value, $expire, $path.'; samesite='.$sameSite, $domain, $secure, $httpOnly);
+} else {
+@setcookie($name, $value, [
+'expire' => $expire,
+'path' => $path,
+'domain' => $domain,
+'secure' => $secure,
+'httponly' => $httpOnly,
+'samesite' => $sameSite,
+]);
+}
 }
 }
 function MAX_cookieClientCookieUnset($name)

--- a/www/delivery/avw.php
+++ b/www/delivery/avw.php
@@ -437,7 +437,7 @@ if ($block > 0 || $setBlock) {
 MAX_cookieAdd("_{$conf['var']['block' . $type]}[{$id}]", MAX_commonGetTimeNow(), _getTimeThirtyDaysFromNow());
 }
 }
-function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null)
+function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null, $secure = null, $httpOnly = false, $sameSite = 'none')
 {
  if (isset($GLOBALS['_OA']['invocationType']) && $GLOBALS['_OA']['invocationType'] == 'xmlrpc') {
 if (!isset($GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'])) {
@@ -445,10 +445,19 @@ $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'] = array();
 }
 $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'][$name] = array($value, $expire);
 } else {
-$secure = !empty($GLOBALS['_MAX']['SSL_REQUEST']);
-$samesite = $secure ? 'none' : 'lax';
-$cookie = new \Symfony\Component\HttpFoundation\Cookie($name, $value, $expire, $path, $domain, $secure, false, false, $samesite);
-MAX_header("Set-Cookie: {$cookie}");
+$secure = $secure ?? !empty($GLOBALS['_MAX']['SSL_REQUEST']);
+if (PHP_VERSION_ID < 70300) {
+@setcookie($name, $value, $expire, $path.'; samesite='.$sameSite, $domain, $secure, $httpOnly);
+} else {
+@setcookie($name, $value, [
+'expire' => $expire,
+'path' => $path,
+'domain' => $domain,
+'secure' => $secure,
+'httponly' => $httpOnly,
+'samesite' => $sameSite,
+]);
+}
 }
 }
 function MAX_cookieClientCookieUnset($name)

--- a/www/delivery/ax.php
+++ b/www/delivery/ax.php
@@ -437,7 +437,7 @@ if ($block > 0 || $setBlock) {
 MAX_cookieAdd("_{$conf['var']['block' . $type]}[{$id}]", MAX_commonGetTimeNow(), _getTimeThirtyDaysFromNow());
 }
 }
-function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null)
+function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null, $secure = null, $httpOnly = false, $sameSite = 'none')
 {
  if (isset($GLOBALS['_OA']['invocationType']) && $GLOBALS['_OA']['invocationType'] == 'xmlrpc') {
 if (!isset($GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'])) {
@@ -445,10 +445,19 @@ $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'] = array();
 }
 $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'][$name] = array($value, $expire);
 } else {
-$secure = !empty($GLOBALS['_MAX']['SSL_REQUEST']);
-$samesite = $secure ? 'none' : 'lax';
-$cookie = new \Symfony\Component\HttpFoundation\Cookie($name, $value, $expire, $path, $domain, $secure, false, false, $samesite);
-MAX_header("Set-Cookie: {$cookie}");
+$secure = $secure ?? !empty($GLOBALS['_MAX']['SSL_REQUEST']);
+if (PHP_VERSION_ID < 70300) {
+@setcookie($name, $value, $expire, $path.'; samesite='.$sameSite, $domain, $secure, $httpOnly);
+} else {
+@setcookie($name, $value, [
+'expire' => $expire,
+'path' => $path,
+'domain' => $domain,
+'secure' => $secure,
+'httponly' => $httpOnly,
+'samesite' => $sameSite,
+]);
+}
 }
 }
 function MAX_cookieClientCookieUnset($name)

--- a/www/delivery/axmlrpc.txt
+++ b/www/delivery/axmlrpc.txt
@@ -437,7 +437,7 @@ if ($block > 0 || $setBlock) {
 MAX_cookieAdd("_{$conf['var']['block' . $type]}[{$id}]", MAX_commonGetTimeNow(), _getTimeThirtyDaysFromNow());
 }
 }
-function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null)
+function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null, $secure = null, $httpOnly = false, $sameSite = 'none')
 {
  if (isset($GLOBALS['_OA']['invocationType']) && $GLOBALS['_OA']['invocationType'] == 'xmlrpc') {
 if (!isset($GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'])) {
@@ -445,10 +445,19 @@ $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'] = array();
 }
 $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'][$name] = array($value, $expire);
 } else {
-$secure = !empty($GLOBALS['_MAX']['SSL_REQUEST']);
-$samesite = $secure ? 'none' : 'lax';
-$cookie = new \Symfony\Component\HttpFoundation\Cookie($name, $value, $expire, $path, $domain, $secure, false, false, $samesite);
-MAX_header("Set-Cookie: {$cookie}");
+$secure = $secure ?? !empty($GLOBALS['_MAX']['SSL_REQUEST']);
+if (PHP_VERSION_ID < 70300) {
+@setcookie($name, $value, $expire, $path.'; samesite='.$sameSite, $domain, $secure, $httpOnly);
+} else {
+@setcookie($name, $value, [
+'expire' => $expire,
+'path' => $path,
+'domain' => $domain,
+'secure' => $secure,
+'httponly' => $httpOnly,
+'samesite' => $sameSite,
+]);
+}
 }
 }
 function MAX_cookieClientCookieUnset($name)

--- a/www/delivery/ck.php
+++ b/www/delivery/ck.php
@@ -437,7 +437,7 @@ if ($block > 0 || $setBlock) {
 MAX_cookieAdd("_{$conf['var']['block' . $type]}[{$id}]", MAX_commonGetTimeNow(), _getTimeThirtyDaysFromNow());
 }
 }
-function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null)
+function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null, $secure = null, $httpOnly = false, $sameSite = 'none')
 {
  if (isset($GLOBALS['_OA']['invocationType']) && $GLOBALS['_OA']['invocationType'] == 'xmlrpc') {
 if (!isset($GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'])) {
@@ -445,10 +445,19 @@ $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'] = array();
 }
 $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'][$name] = array($value, $expire);
 } else {
-$secure = !empty($GLOBALS['_MAX']['SSL_REQUEST']);
-$samesite = $secure ? 'none' : 'lax';
-$cookie = new \Symfony\Component\HttpFoundation\Cookie($name, $value, $expire, $path, $domain, $secure, false, false, $samesite);
-MAX_header("Set-Cookie: {$cookie}");
+$secure = $secure ?? !empty($GLOBALS['_MAX']['SSL_REQUEST']);
+if (PHP_VERSION_ID < 70300) {
+@setcookie($name, $value, $expire, $path.'; samesite='.$sameSite, $domain, $secure, $httpOnly);
+} else {
+@setcookie($name, $value, [
+'expire' => $expire,
+'path' => $path,
+'domain' => $domain,
+'secure' => $secure,
+'httponly' => $httpOnly,
+'samesite' => $sameSite,
+]);
+}
 }
 }
 function MAX_cookieClientCookieUnset($name)

--- a/www/delivery/lg.php
+++ b/www/delivery/lg.php
@@ -437,7 +437,7 @@ if ($block > 0 || $setBlock) {
 MAX_cookieAdd("_{$conf['var']['block' . $type]}[{$id}]", MAX_commonGetTimeNow(), _getTimeThirtyDaysFromNow());
 }
 }
-function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null)
+function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null, $secure = null, $httpOnly = false, $sameSite = 'none')
 {
  if (isset($GLOBALS['_OA']['invocationType']) && $GLOBALS['_OA']['invocationType'] == 'xmlrpc') {
 if (!isset($GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'])) {
@@ -445,10 +445,19 @@ $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'] = array();
 }
 $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'][$name] = array($value, $expire);
 } else {
-$secure = !empty($GLOBALS['_MAX']['SSL_REQUEST']);
-$samesite = $secure ? 'none' : 'lax';
-$cookie = new \Symfony\Component\HttpFoundation\Cookie($name, $value, $expire, $path, $domain, $secure, false, false, $samesite);
-MAX_header("Set-Cookie: {$cookie}");
+$secure = $secure ?? !empty($GLOBALS['_MAX']['SSL_REQUEST']);
+if (PHP_VERSION_ID < 70300) {
+@setcookie($name, $value, $expire, $path.'; samesite='.$sameSite, $domain, $secure, $httpOnly);
+} else {
+@setcookie($name, $value, [
+'expire' => $expire,
+'path' => $path,
+'domain' => $domain,
+'secure' => $secure,
+'httponly' => $httpOnly,
+'samesite' => $sameSite,
+]);
+}
 }
 }
 function MAX_cookieClientCookieUnset($name)

--- a/www/delivery/spc.php
+++ b/www/delivery/spc.php
@@ -437,7 +437,7 @@ if ($block > 0 || $setBlock) {
 MAX_cookieAdd("_{$conf['var']['block' . $type]}[{$id}]", MAX_commonGetTimeNow(), _getTimeThirtyDaysFromNow());
 }
 }
-function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null)
+function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null, $secure = null, $httpOnly = false, $sameSite = 'none')
 {
  if (isset($GLOBALS['_OA']['invocationType']) && $GLOBALS['_OA']['invocationType'] == 'xmlrpc') {
 if (!isset($GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'])) {
@@ -445,10 +445,19 @@ $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'] = array();
 }
 $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'][$name] = array($value, $expire);
 } else {
-$secure = !empty($GLOBALS['_MAX']['SSL_REQUEST']);
-$samesite = $secure ? 'none' : 'lax';
-$cookie = new \Symfony\Component\HttpFoundation\Cookie($name, $value, $expire, $path, $domain, $secure, false, false, $samesite);
-MAX_header("Set-Cookie: {$cookie}");
+$secure = $secure ?? !empty($GLOBALS['_MAX']['SSL_REQUEST']);
+if (PHP_VERSION_ID < 70300) {
+@setcookie($name, $value, $expire, $path.'; samesite='.$sameSite, $domain, $secure, $httpOnly);
+} else {
+@setcookie($name, $value, [
+'expire' => $expire,
+'path' => $path,
+'domain' => $domain,
+'secure' => $secure,
+'httponly' => $httpOnly,
+'samesite' => $sameSite,
+]);
+}
 }
 }
 function MAX_cookieClientCookieUnset($name)

--- a/www/delivery/spcjs.php
+++ b/www/delivery/spcjs.php
@@ -437,7 +437,7 @@ if ($block > 0 || $setBlock) {
 MAX_cookieAdd("_{$conf['var']['block' . $type]}[{$id}]", MAX_commonGetTimeNow(), _getTimeThirtyDaysFromNow());
 }
 }
-function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null)
+function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null, $secure = null, $httpOnly = false, $sameSite = 'none')
 {
  if (isset($GLOBALS['_OA']['invocationType']) && $GLOBALS['_OA']['invocationType'] == 'xmlrpc') {
 if (!isset($GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'])) {
@@ -445,10 +445,19 @@ $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'] = array();
 }
 $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'][$name] = array($value, $expire);
 } else {
-$secure = !empty($GLOBALS['_MAX']['SSL_REQUEST']);
-$samesite = $secure ? 'none' : 'lax';
-$cookie = new \Symfony\Component\HttpFoundation\Cookie($name, $value, $expire, $path, $domain, $secure, false, false, $samesite);
-MAX_header("Set-Cookie: {$cookie}");
+$secure = $secure ?? !empty($GLOBALS['_MAX']['SSL_REQUEST']);
+if (PHP_VERSION_ID < 70300) {
+@setcookie($name, $value, $expire, $path.'; samesite='.$sameSite, $domain, $secure, $httpOnly);
+} else {
+@setcookie($name, $value, [
+'expire' => $expire,
+'path' => $path,
+'domain' => $domain,
+'secure' => $secure,
+'httponly' => $httpOnly,
+'samesite' => $sameSite,
+]);
+}
 }
 }
 function MAX_cookieClientCookieUnset($name)

--- a/www/delivery/ti.php
+++ b/www/delivery/ti.php
@@ -437,7 +437,7 @@ if ($block > 0 || $setBlock) {
 MAX_cookieAdd("_{$conf['var']['block' . $type]}[{$id}]", MAX_commonGetTimeNow(), _getTimeThirtyDaysFromNow());
 }
 }
-function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null)
+function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null, $secure = null, $httpOnly = false, $sameSite = 'none')
 {
  if (isset($GLOBALS['_OA']['invocationType']) && $GLOBALS['_OA']['invocationType'] == 'xmlrpc') {
 if (!isset($GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'])) {
@@ -445,10 +445,19 @@ $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'] = array();
 }
 $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'][$name] = array($value, $expire);
 } else {
-$secure = !empty($GLOBALS['_MAX']['SSL_REQUEST']);
-$samesite = $secure ? 'none' : 'lax';
-$cookie = new \Symfony\Component\HttpFoundation\Cookie($name, $value, $expire, $path, $domain, $secure, false, false, $samesite);
-MAX_header("Set-Cookie: {$cookie}");
+$secure = $secure ?? !empty($GLOBALS['_MAX']['SSL_REQUEST']);
+if (PHP_VERSION_ID < 70300) {
+@setcookie($name, $value, $expire, $path.'; samesite='.$sameSite, $domain, $secure, $httpOnly);
+} else {
+@setcookie($name, $value, [
+'expire' => $expire,
+'path' => $path,
+'domain' => $domain,
+'secure' => $secure,
+'httponly' => $httpOnly,
+'samesite' => $sameSite,
+]);
+}
 }
 }
 function MAX_cookieClientCookieUnset($name)

--- a/www/delivery/tjs.php
+++ b/www/delivery/tjs.php
@@ -437,7 +437,7 @@ if ($block > 0 || $setBlock) {
 MAX_cookieAdd("_{$conf['var']['block' . $type]}[{$id}]", MAX_commonGetTimeNow(), _getTimeThirtyDaysFromNow());
 }
 }
-function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null)
+function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null, $secure = null, $httpOnly = false, $sameSite = 'none')
 {
  if (isset($GLOBALS['_OA']['invocationType']) && $GLOBALS['_OA']['invocationType'] == 'xmlrpc') {
 if (!isset($GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'])) {
@@ -445,10 +445,19 @@ $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'] = array();
 }
 $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'][$name] = array($value, $expire);
 } else {
-$secure = !empty($GLOBALS['_MAX']['SSL_REQUEST']);
-$samesite = $secure ? 'none' : 'lax';
-$cookie = new \Symfony\Component\HttpFoundation\Cookie($name, $value, $expire, $path, $domain, $secure, false, false, $samesite);
-MAX_header("Set-Cookie: {$cookie}");
+$secure = $secure ?? !empty($GLOBALS['_MAX']['SSL_REQUEST']);
+if (PHP_VERSION_ID < 70300) {
+@setcookie($name, $value, $expire, $path.'; samesite='.$sameSite, $domain, $secure, $httpOnly);
+} else {
+@setcookie($name, $value, [
+'expire' => $expire,
+'path' => $path,
+'domain' => $domain,
+'secure' => $secure,
+'httponly' => $httpOnly,
+'samesite' => $sameSite,
+]);
+}
 }
 }
 function MAX_cookieClientCookieUnset($name)

--- a/www/delivery/tv.php
+++ b/www/delivery/tv.php
@@ -437,7 +437,7 @@ if ($block > 0 || $setBlock) {
 MAX_cookieAdd("_{$conf['var']['block' . $type]}[{$id}]", MAX_commonGetTimeNow(), _getTimeThirtyDaysFromNow());
 }
 }
-function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null)
+function MAX_cookieClientCookieSet($name, $value, $expire, $path = '/', $domain = null, $secure = null, $httpOnly = false, $sameSite = 'none')
 {
  if (isset($GLOBALS['_OA']['invocationType']) && $GLOBALS['_OA']['invocationType'] == 'xmlrpc') {
 if (!isset($GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'])) {
@@ -445,10 +445,19 @@ $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'] = array();
 }
 $GLOBALS['_OA']['COOKIE']['XMLRPC_CACHE'][$name] = array($value, $expire);
 } else {
-$secure = !empty($GLOBALS['_MAX']['SSL_REQUEST']);
-$samesite = $secure ? 'none' : 'lax';
-$cookie = new \Symfony\Component\HttpFoundation\Cookie($name, $value, $expire, $path, $domain, $secure, false, false, $samesite);
-MAX_header("Set-Cookie: {$cookie}");
+$secure = $secure ?? !empty($GLOBALS['_MAX']['SSL_REQUEST']);
+if (PHP_VERSION_ID < 70300) {
+@setcookie($name, $value, $expire, $path.'; samesite='.$sameSite, $domain, $secure, $httpOnly);
+} else {
+@setcookie($name, $value, [
+'expire' => $expire,
+'path' => $path,
+'domain' => $domain,
+'secure' => $secure,
+'httponly' => $httpOnly,
+'samesite' => $sameSite,
+]);
+}
 }
 }
 function MAX_cookieClientCookieUnset($name)


### PR DESCRIPTION
Sadly, I had to remove `symfony/http-foundation` as it would have required hacking some ResponseHeaderBag into the delivery cookie functions, whereas `MAX_cookieClientCookieSet()` was supposed to "set" the cookie directly.