### PR TITLE
Speed up _adSelectBuildContext processing

### DIFF
--- a/lib/max/Delivery/adSelect.php
+++ b/lib/max/Delivery/adSelect.php
@@ -1108,7 +1108,7 @@ function _adSelectBuildContext($aBanner, $context = array()) {
 	//prepare information for check exists calls
 	$data = [];
         foreach ($context as $c){
-            if(!in_array(key($c), $data[current($c)])){
+            if(!isset($data[current($c)][key($c)])){
                 $data[current($c)][] = key($c);
             }
         }
@@ -1119,12 +1119,12 @@ function _adSelectBuildContext($aBanner, $context = array()) {
             $value = 'companionid:'.$companionCampaign;
             if ($aBanner['placement_id'] == $companionCampaign) {
                 $context[] = array('==' => $value);
-		if(!in_array('==', $data[$value])){
+		if(!isset($data[$value]['=='])){
                     $data[$value][] = '==';
                 }
             } else {
                 // Did we previously deliver an ad from this campaign?
-                if (empty($data[$value]) ||  !in_array('==', $data[$value])) {
+                if(!isset($data[$value]['=='])){
                     $context[] = array('!=' => $value);
                 }
             }

--- a/lib/max/Delivery/adSelect.php
+++ b/lib/max/Delivery/adSelect.php
@@ -1105,6 +1105,13 @@ function _adSelectBuildContextArray(&$aLinkedAds, $adArrayVar, $context, $compan
  */
 function _adSelectBuildContext($aBanner, $context = array()) {
     if (!empty($aBanner['zone_companion'])) {
+	//prepare information for check exists calls
+	$data = [];
+        foreach ($context as $c){
+            if(!in_array(key($c), $data[current($c)])){
+                $data[current($c)][] = key($c);
+            }
+        }
         // This zone call has companion banners linked to it.
         // So pass into the next call that we would like a banner from this campaign
         // and not from the other companion linked campaigns
@@ -1112,11 +1119,12 @@ function _adSelectBuildContext($aBanner, $context = array()) {
             $value = 'companionid:'.$companionCampaign;
             if ($aBanner['placement_id'] == $companionCampaign) {
                 $context[] = array('==' => $value);
+		if(!in_array('==', $data[$value])){
+                    $data[$value][] = '==';
+                }
             } else {
                 // Did we previously deliver an ad from this campaign?
-                $key = array_search(array('==', $value), $context);
-                if ($key === false) {
-                    // Nope, we must exclude the campaign then!
+                if (empty($data[$value]) ||  !in_array('==', $data[$value])) {
                     $context[] = array('!=' => $value);
                 }
             }


### PR DESCRIPTION
Currently, we have about 97k banners, when system processing about 20k at one time `_adSelectBuildContext` function takes a long time. 
The biggest time take `array_search()` function.

Request with array_search - https://prnt.sc/rou3q9
Request with an array - https://prnt.sc/rou54u