### PR TITLE
Delivery engine to check/use TLS for database connections (#1295)

### DIFF
--- a/lib/OA/Dal/Delivery/mysqli.php
+++ b/lib/OA/Dal/Delivery/mysqli.php
@@ -52,7 +52,23 @@ function OA_Dal_Delivery_connect($database = 'database') {
 
     if ($dbConf['protocol'] == 'unix' && !empty($dbConf['socket'])) {
         $dbLink = @mysqli_connect($dbPersistent.'localhost', $dbUser, $dbPassword, $dbName, $dbPort, $dbConf['socket']);
-    } else {
+    }
+    elseif ($dbConf['ssl']) {
+        $init = mysqli_init();
+        mysqli_ssl_set(
+            $init,
+            null,
+            null,
+            empty($dbConf['ca']) ? null : $dbConf['ca'],
+            empty($dbConf['capath']) ? null : $dbConf['capath'],
+            null,
+        );
+        if ( $dbLink = @mysqli_real_connect($init, $dbPersistent.$dbHost, $dbUser, $dbPassword, $dbName, $dbPort) ) {
+            // Connection successful (else: $dbLink == false)
+            $dbLink = $init;
+        }
+    }
+    else {
         $dbLink = @mysqli_connect($dbPersistent.$dbHost, $dbUser, $dbPassword, $dbName, $dbPort);
     }
 


### PR DESCRIPTION
Re #1295

Have tested this against our live system (mysqli) with no problems to report.
From what I could see, the same issue would be present for mysql / Postgres. I don't have a suitable environment to test against though.
By all means edit this as you see fit @mbeccati

Cheers!