### PR TITLE
Prevent PHP execution in images/ folder

### DIFF
--- a/www/images/.htaccess
+++ b/www/images/.htaccess
@@ -1,0 +1,1 @@
+php_flag engine off


### PR DESCRIPTION
This `.htaccess` turns off PHP execution in the `images` folder for Apache installations.

Why ?

In the past years, I've been contracted several times to fix hacked (outdated) revive installations.
Most of the time, a backdoor was injected as a PHP file in the images/ folder, it stayed dormant, then was executed at some point by a direct call to the PHP file.

Hope this PR is not short-sighted and doesn't miss something obvious that explain why this haven't been done before.

Cheers