### PR TITLE
Adding lazy load of the banner images

### DIFF
--- a/www/delivery/asyncspc.php
+++ b/www/delivery/asyncspc.php
@@ -3444,7 +3444,7 @@ $imgStatus = empty($clickTag) && !empty($status) ? $status : '';
 $width = !empty($aBanner['width']) ? $aBanner['width'] : 0;
 $height = !empty($aBanner['height']) ? $aBanner['height'] : 0;
 $alt = !empty($aBanner['alt']) ? htmlspecialchars($aBanner['alt'], ENT_QUOTES) : '';
-$imageTag = "$clickTag<img src='" . htmlspecialchars($imageUrl, ENT_QUOTES) . "' width='$width' height='$height' alt='$alt' title='$alt' border='0'$imgStatus />$clickTagEnd";
+$imageTag = "$clickTag<img src='" . htmlspecialchars($imageUrl, ENT_QUOTES) . "' width='$width' height='$height' alt='$alt' title='$alt' loading='lazy' border='0'$imgStatus />$clickTagEnd";
 } else {
 $imageTag = '';
 }


### PR DESCRIPTION
Performance increase, by adding lazyload of images.

Everything in regards to images on internet today is lazyload, and banners could be as well.

Suggested in this thread:
https://forum.revive-adserver.com/topic/6024-loadinglazy-gained-3-4-points-in-pagespeed-insights/