### PR TITLE
Add rel attribute for banner links

### DIFF
--- a/etc/dist.conf.php
+++ b/etc/dist.conf.php
@@ -136,6 +136,7 @@ secret                              =
 clickUrlValidity                    = 0;    ; Click URL open redirect validity in seconds
 
 [defaultBanner]
+relAttribute                        = noopener sponsored
 invalidZoneHtmlBanner               =       ; If zone does not exist, show this HTML snipper
 suspendedAccountHtmlBanner          =       ; If account is suspended, show this HTML snippet
 inactiveAccountHtmlBanner           =       ; If account is inactive, show this HTML snippet

--- a/lib/max/Delivery/adRender.php
+++ b/lib/max/Delivery/adRender.php
@@ -319,7 +319,7 @@ function _adRenderImage(&$aBanner, $zoneId = 0, $source = '', $ct0 = '', $withTe
     if (!empty($aBanner['url'])) {  // There is a link
         $status = _adRenderBuildStatusCode($aBanner);
         $relAttribute = !empty($conf['defaultBanner']['relAttribute']) ? ' rel="' . $conf['defaultBanner']['relAttribute'] . '"' : '';
-        $clickTag = "<a href='{clickurl_html}' target='{target}'$rel{$status}>";
+        $clickTag = "<a href='{clickurl_html}' target='{target}'$relAttribute{$status}>";
         $clickTagEnd = '</a>';
     } else {
         $clickTag = '';

--- a/lib/max/Delivery/adRender.php
+++ b/lib/max/Delivery/adRender.php
@@ -318,7 +318,8 @@ function _adRenderImage(&$aBanner, $zoneId = 0, $source = '', $ct0 = '', $withTe
     // Create the anchor tag..
     if (!empty($aBanner['url'])) {  // There is a link
         $status = _adRenderBuildStatusCode($aBanner);
-        $clickTag = "<a href='{clickurl_html}' target='{target}'{$status}>";
+        $relAttribute = !empty($conf['defaultBanner']['relAttribute']) ? ' rel="' . $conf['defaultBanner']['relAttribute'] . '"' : '';
+        $clickTag = "<a href='{clickurl_html}' target='{target}'$rel{$status}>";
         $clickTagEnd = '</a>';
     } else {
         $clickTag = '';

--- a/lib/max/language/en/settings.lang.php
+++ b/lib/max/language/en/settings.lang.php
@@ -192,6 +192,7 @@ $GLOBALS['strDeliveryAcls'] = "Evaluate banner delivery rules during delivery";
 $GLOBALS['strDeliveryAclsDirectSelection'] = "Evaluate banner delivery rules for direct selected ads";
 $GLOBALS['strDeliveryObfuscate'] = "Obfuscate delivery rule set when delivering ads";
 $GLOBALS['strDeliveryClickUrlValidity'] = "Validity of custom destination URL redirects in {clickurl} macros (seconds). Enter 0 to disallow redirects";
+$GLOBALS['strGlobalDefaultBannerRelAttribute'] = "Global default Banner rel attribute";
 $GLOBALS['strGlobalDefaultBannerInvalidZone'] = "Global default HTML Banner for non-existing zones";
 $GLOBALS['strGlobalDefaultBannerSuspendedAccount'] = "Global default HTML Banner for suspended accounts";
 $GLOBALS['strGlobalDefaultBannerInactiveAccount'] = "Global default HTML Banner for inactive accounts";

--- a/www/admin/account-settings-banner-delivery.php
+++ b/www/admin/account-settings-banner-delivery.php
@@ -66,6 +66,7 @@ if (isset($_POST['submitok']) && $_POST['submitok'] == 'true') {
             'bool' => true
         ],
         'delivery_clickUrlValidity' => ['delivery' => 'clickUrlValidity'],
+        'defaultBanner_relAttribute' => ['defaultBanner' => 'relAttribute'],
         'defaultBanner_invalidZoneHtmlBanner' => ['defaultBanner' => 'invalidZoneHtmlBanner'],
         'defaultBanner_suspendedAccountHtmlBanner' => ['defaultBanner' => 'suspendedAccountHtmlBanner'],
         'defaultBanner_inactiveAccountHtmlBanner' => ['defaultBanner' => 'inactiveAccountHtmlBanner'],
@@ -262,6 +263,14 @@ $aSettings = [
             ],
             [
                 'type' => 'break'
+            ],
+            [
+                'type'    => 'text',
+                'name'    => 'defaultBanner_relAttribute',
+                'text'    => $strGlobalDefaultBannerRelAttribute,
+            ],
+            [
+                'type'    => 'break'
             ],
             [
                 'type' => 'textarea',


### PR DESCRIPTION
Links should have a rel attribute according to google:
https://developers.google.com/search/docs/advanced/guidelines/qualify-outbound-links

For security reasons there should be 'noopener' also (#1106).