### PR TITLE
Ref #1363 Do not send welcome email to existing users

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -215,10 +215,6 @@ this before reporting any new bugs.
    statistics. This can be worked around by ensuring that the timezone is
    correctly set in PHP.
 
- * With v5.4.0 and higher, when a new user has been created but the new user has
-   not set their password yet, making changes to the user's permissions will
-   trigger the 'welcome new user' email with the password reset link again.
-
  * See https://www.revive-adserver.com/support/bugs/ for the latest bug reports.
 
 

--- a/lib/OA/Admin/UI/UserAccess.php
+++ b/lib/OA/Admin/UI/UserAccess.php
@@ -24,7 +24,10 @@ class OA_Admin_UI_UserAccess
     public $request = [];
     public $pagePrefix; // admin/agency/advertiser/affiliate
     public $aErrors = [];
+
+    /** @var Plugins_Authentication */
     public $oPlugin;
+
     public $callbackHeaderNavigation;
     public $callbackFooterNavigation;
     public $aAllowedPermissions = [];
@@ -102,7 +105,10 @@ class OA_Admin_UI_UserAccess
             } else {
                 $this->aErrors = $this->oPlugin->validateUsersData($this->request);
             }
+
             if (empty($this->aErrors)) {
+                $newUser = empty($this->userid);
+
                 $this->userid = $this->oPlugin->saveUser(
                     $this->userid,
                     $this->request['login'],
@@ -121,7 +127,7 @@ class OA_Admin_UI_UserAccess
                         $this->aAllowedPermissions
                     );
 
-                    if ($this->oPasswordRecovery->sendWelcomeEmail([$this->userid]) > 0) {
+                    if ($newUser && $this->oPasswordRecovery->sendWelcomeEmail([$this->userid]) > 0) {
                         OA_Session::setMessage($GLOBALS['strUserLinkedAndWelcomeSent']);
                     }
 

--- a/lib/OX/Extension/authentication/authentication.php
+++ b/lib/OX/Extension/authentication/authentication.php
@@ -356,6 +356,7 @@ class Plugins_Authentication extends OX_Component
         $language,
         $accountId
     ) {
+        /** @var DataObjects_Users $doUsers */
         $doUsers = OA_Dal::factoryDO('users');
         $doUsers->loadByProperty('user_id', $userid);
 
@@ -374,7 +375,7 @@ class Plugins_Authentication extends OX_Component
      * Method used in user access pages. Either creates new user if
      * necessary or update existing one.
      *
-     * @param DB_DataObject_Users $doUsers  Users dataobject with any preset variables
+     * @param DataObjects_Users $doUsers  Users dataobject with any preset variables
      * @param string $login  User name
      * @param string|null $password  Password
      * @param string $contactName  Contact name
@@ -383,7 +384,7 @@ class Plugins_Authentication extends OX_Component
      * @return integer  User ID or false on error
      */
     public function saveUserDo(
-        &$doUsers,
+        $doUsers,
         $login,
         $password,
         $contactName,


### PR DESCRIPTION
Following the principle of least surprise, existing users won't receive a new welcome email when permissions are changed or they are linked to other accounts before setting up their password.