### PR TITLE
Use $conf['cookie']['domain'] also for admin cookie

### DIFF
--- a/www/admin/lib-sessions.inc.php
+++ b/www/admin/lib-sessions.inc.php
@@ -64,13 +64,21 @@ function phpAds_SessionDataFetch()
 function phpAds_SessionSetAdminCookie($name, $value)
 {
     $conf = $GLOBALS['_MAX']['CONF'];
+    
+    $domain = null;
+    if(!empty($conf['cookie']['domain'])){
+        $domain = $conf['cookie']['domain'];
+    }
+    elseif(!empty($_SERVER['HTTP_HOST'])){
+        preg_replace('#:\d+$#', '', $_SERVER['HTTP_HOST']);
+    }
 
     MAX_cookieClientCookieSet(
         $name,
         $value,
         0,
         dirname($_SERVER["SCRIPT_NAME"]),
-        empty($_SERVER['HTTP_HOST']) ? null : preg_replace('#:\d+$#', '', $_SERVER['HTTP_HOST']),
+        $domain,
         !empty($conf['openads']['requireSSL']),
         true,
         'strict'


### PR DESCRIPTION
The configuration
...
[cookie]
domain="proxy.mydomain.test"
...
is not taken into account for the admin cookie. Thus admin login is not possible. This commit uses $conf['cookie']['domain'] if not empty.

Thanks to Ibanson, who inspired this fix with this forum post: https://forum.revive-adserver.com/topic/3226-unable-to-log-in-you-need-to-enable-cookies-before-you-can-use-revive-adserver/#comment-6931.