### PR TITLE
Xmlrpc preload pear : Prevent some die call

### DIFF
--- a/lib/xmlrpc/php/openads-api-xmlrpc.inc.php
+++ b/lib/xmlrpc/php/openads-api-xmlrpc.inc.php
@@ -10,6 +10,7 @@
 +---------------------------------------------------------------------------+
 */
 
+set_include_path(get_include_path() . PATH_SEPARATOR . __DIR__."/../../pear/");
 if (!@include_once('XML/RPC.php')) {
     die('Error: cannot load the PEAR XML_RPC class');
 }

--- a/lib/xmlrpc/php/openads-api-xmlrpc.inc.php
+++ b/lib/xmlrpc/php/openads-api-xmlrpc.inc.php
@@ -10,7 +10,7 @@
 +---------------------------------------------------------------------------+
 */
 
-if (!@include('XML/RPC.php')) {
+if (!@include_once('XML/RPC.php')) {
     die('Error: cannot load the PEAR XML_RPC class');
 }
 

--- a/lib/xmlrpc/php/openads-xmlrpc.inc.php
+++ b/lib/xmlrpc/php/openads-xmlrpc.inc.php
@@ -10,7 +10,7 @@
 +---------------------------------------------------------------------------+
 */
 
-if (!@include('XML/RPC.php')) {
+if (!@include_once('XML/RPC.php')) {
     die("Error: cannot load the PEAR XML_RPC class");
 }
 

--- a/lib/xmlrpc/php/openads-xmlrpc.inc.php
+++ b/lib/xmlrpc/php/openads-xmlrpc.inc.php
@@ -10,6 +10,7 @@
 +---------------------------------------------------------------------------+
 */
 
+set_include_path(get_include_path() . PATH_SEPARATOR . __DIR__."/../../pear/");
 if (!@include_once('XML/RPC.php')) {
     die("Error: cannot load the PEAR XML_RPC class");
 }

--- a/lib/xmlrpc/php/openx-api-v2-xmlrpc.inc.php
+++ b/lib/xmlrpc/php/openx-api-v2-xmlrpc.inc.php
@@ -10,6 +10,7 @@
 +---------------------------------------------------------------------------+
 */
 
+set_include_path(get_include_path() . PATH_SEPARATOR . __DIR__."/../../pear/");
 if (!@include_once('XML/RPC.php')) {
     die('Error: cannot load the PEAR XML_RPC class');
 }

--- a/lib/xmlrpc/php/openx-api-v2-xmlrpc.inc.php
+++ b/lib/xmlrpc/php/openx-api-v2-xmlrpc.inc.php
@@ -10,7 +10,7 @@
 +---------------------------------------------------------------------------+
 */
 
-if (!@include('XML/RPC.php')) {
+if (!@include_once('XML/RPC.php')) {
     die('Error: cannot load the PEAR XML_RPC class');
 }
 


### PR DESCRIPTION
As code is provided, xmlrpc class require to install pear class from server.
But revive provided yet this code then we could include all path and prevent some multi include code.

Related to : 
* https://forum.revive-adserver.com/topic/4739-how-to-use-the-xml-rpc-tag/