### PR TITLE
Maintenance cron crash fix due to double campaign update

### DIFF
--- a/lib/OX/Dal/Maintenance/Statistics.php
+++ b/lib/OX/Dal/Maintenance/Statistics.php
@@ -1477,8 +1477,8 @@ abstract class OX_Dal_Maintenance_Statistics extends MAX_Dal_Common
                             phpAds_userlogSetUser(phpAds_userMaintenance);
                             phpAds_userlogAdd(phpAds_actionDeactiveCampaign, $aCampaign['campaign_id']);
                         } else {
-                            // The campaign didn't have a diable reason,
-                            // it *might* possibly be diabled "soon"...
+                            // The campaign didn't have a disable reason,
+                            // it *might* possibly be disabled "soon"...
                             $canExpireSoon = true;
                         }
                     }

--- a/lib/OX/Dal/Maintenance/Statistics.php
+++ b/lib/OX/Dal/Maintenance/Statistics.php
@@ -1464,8 +1464,15 @@ abstract class OX_Dal_Maintenance_Statistics extends MAX_Dal_Common
                             $doCampaigns->fetch();
                             $doCampaigns->status = OA_ENTITY_STATUS_EXPIRED;
                             $result = $doCampaigns->update();
-                            if ($result == false) {
-                                MAX::raiseError("Could not update campaign {$aCampaign['campaign_id']}", MAX_ERROR_DBFAILURE, PEAR_ERROR_DIE);
+                            if ($result === 0)
+                            {
+                                OA::debug("Update campaign {$aCampaign['campaign_id']} has no effect", PEAR_LOG_DEBUG);
+                            }
+                            elseif ($result === false) {
+                                MAX::raiseError("Could not update campaign {$aCampaign['campaign_id']}", MAX_ERROR_DBFAILURE, PEAR_LOG_DEBUG);
+                            }
+                            else{
+                                OA::debug("Campaign {$aCampaign['campaign_id']} has been updated", PEAR_LOG_DEBUG);
                             }
                             phpAds_userlogSetUser(phpAds_userMaintenance);
                             phpAds_userlogAdd(phpAds_actionDeactiveCampaign, $aCampaign['campaign_id']);
@@ -1494,8 +1501,15 @@ abstract class OX_Dal_Maintenance_Statistics extends MAX_Dal_Common
                         $doCampaigns->fetch();
                         $doCampaigns->status = OA_ENTITY_STATUS_EXPIRED;
                         $result = $doCampaigns->update();
-                        if ($result == false) {
+                        if ($result === 0)
+                        {
+                            OA::debug("Update campaign {$aCampaign['campaign_id']} has no effect", PEAR_LOG_DEBUG);
+                        }
+                        elseif ($result === false) {
                             MAX::raiseError("Could not update campaign {$aCampaign['campaign_id']}", MAX_ERROR_DBFAILURE, PEAR_ERROR_DIE);
+                        }
+                        else{
+                            OA::debug("Campaign {$aCampaign['campaign_id']} has been updated", PEAR_LOG_DEBUG);
                         }
                         phpAds_userlogSetUser(phpAds_userMaintenance);
                         phpAds_userlogAdd(phpAds_actionDeactiveCampaign, $aCampaign['campaign_id']);
@@ -1601,8 +1615,15 @@ abstract class OX_Dal_Maintenance_Statistics extends MAX_Dal_Common
                     $doCampaigns->fetch();
                     $doCampaigns->status = OA_ENTITY_STATUS_RUNNING;
                     $result = $doCampaigns->update();
-                    if ($result == false) {
+                    if ($result === 0)
+                    {
+                        OA::debug("Update campaign {$aCampaign['campaign_id']} has no effect", PEAR_LOG_DEBUG);
+                    }
+                    elseif ($result === false) {
                         MAX::raiseError("Could not update campaign {$aCampaign['campaign_id']}", MAX_ERROR_DBFAILURE, PEAR_ERROR_DIE);
+                    }
+                    else{
+                        OA::debug("Campaign {$aCampaign['campaign_id']} has been updated", PEAR_LOG_DEBUG);
                     }
                     phpAds_userlogSetUser(phpAds_userMaintenance);
                     phpAds_userlogAdd(phpAds_actionActiveCampaign, $aCampaign['campaign_id']);

--- a/lib/max/Dal/DataObjects/DB_DataObjectCommon.php
+++ b/lib/max/Dal/DataObjects/DB_DataObjectCommon.php
@@ -697,7 +697,7 @@ class DB_DataObjectCommon extends DB_DataObject
      *                          which case the current object's whereAdd()
      *                          method call value will be used to idenfity
      *                          one or more rows which will *all* be updated.
-     * @return boolean True on update success, false otherwise.
+     * @return int|boolean int rows affected on success or false on failure.
      */
     public function update($dataObject = false)
     {


### PR DESCRIPTION
There are more reasons to update campaign during maintenance cron and it can cause a crash with message `Could not update campaign  XXX`, err code `-111` because of non-strict type check. `0 == false`.

```
$result = $doCampaigns->update();
if ($result == false) {
     MAX::raiseError("Could not update campaign {$aCampaign['campaign_id']}", MAX_ERROR_DBFAILURE, PEAR_ERROR_DIE);
}
```

`$result` is not strictly `bool` (fixed PHPDoc), but it can contains `int` as number of affected rows and when it can do this same update two times, the second one will not affect any rows.