### PR TITLE
Improve data_summary_ad_zone_assoc pruning

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -42,6 +42,8 @@ New Features
    and a new UI setting to disable or customise how long to wait before
    displaying the loader (defaults to 250ms).
 
+ * Improved pruning of the data_summary_ad_zone_assoc table.
+
 
 Bug Fixes
 ---------

--- a/lib/OA/Dal/Maintenance/Priority.php
+++ b/lib/OA/Dal/Maintenance/Priority.php
@@ -1763,7 +1763,7 @@ class OA_Dal_Maintenance_Priority extends OA_Dal_Maintenance_Common
             }
         }
         // Expire the old priority values in data_summary_ad_zone_assoc
-        OA::debug("  - Epiring old priority values in {$aConf['table']['data_summary_ad_zone_assoc']}", PEAR_LOG_DEBUG);
+        OA::debug("  - Expiring old priority values in {$aConf['table']['data_summary_ad_zone_assoc']}", PEAR_LOG_DEBUG);
         $table = $this->_getTablename('data_summary_ad_zone_assoc');
         $query = "
             UPDATE

--- a/lib/OA/Maintenance/Pruning.php
+++ b/lib/OA/Maintenance/Pruning.php
@@ -62,26 +62,54 @@ class OA_Maintenance_Pruning extends MAX_Dal_Common
     }
 
     /**
-     * A method to prune the data_summary_ad_zone_assoc table
-     * Pruning can be performed where zone_id = 0 (i.e. for direct selection) and where the entry is older than MAX_PREVIOUS_AD_DELIVERY_INFO_LIMIT minutes ago.
+     * A method to prune the data_summary_ad_zone_assoc table.
+     *
+     * Pruning can be performed where the entry is older than MAX_PREVIOUS_AD_DELIVERY_INFO_LIMIT minutes ago.
+     * If the table has more than 100k rows and more than 60% of the rows is expected to be pruned,
+     * the strategy changes: the rows to be kept are copied to a temporary table, the DSAZA table is truncated
+     * and the
      *
      * @return integer : number of records deleted
      */
-    public function _pruneDataSummaryAdZoneAssocOldData()
+    public function _pruneDataSummaryAdZoneAssocOldData(int $useTruncateThreshold = 100000)
     {
-        $doDSAZA = OA_Dal::factoryDO('data_summary_ad_zone_assoc');
-        $doDSAZA->whereAdd('zone_id=0', 'AND');
-        $doDSAZA->whereAdd('created < DATE_ADD('
-                            . $this->oDbh->quote(OA::getNow()) . ', '
-                            . OA_Dal::quoteInterval(-MAX_PREVIOUS_AD_DELIVERY_INFO_LIMIT, 'SECOND')
-                            . ')', 'AND');
-        return $doDSAZA->delete(true, false);
+        $tblAssoc = $this->_getTablename('data_summary_ad_zone_assoc');
+
+        $oServiceLocator = OA_ServiceLocator::instance();
+        /** @var Date $oDate */
+        $oDate = clone $oServiceLocator->get('now');
+        $oDate->subtractSeconds(MAX_PREVIOUS_AD_DELIVERY_INFO_LIMIT * 60);
+
+        $qDate = $this->oDbh->quote($oDate->getDate());
+
+        // Get total and old records
+        $row = array_map('intval', $this->oDbh->queryRow("
+            SELECT
+                COUNT(*) AS cnt,
+                COALESCE(SUM(IF(interval_start < {$qDate}, 1, 0)), 0) AS old
+            FROM {$tblAssoc}
+        "));
+
+        if (0 === $row['cnt']) {
+            return 0;
+        }
+
+        try {
+            if ($row['cnt'] >= $useTruncateThreshold && $row['old'] / $row['cnt'] > 0.6) {
+                OA::debug('Optimized pruning in use', PEAR_LOG_DEBUG);
+                return $row['cnt'] - $this->pruneDSAZAOldDataWithTempTable($tblAssoc, $qDate);
+            }
+        } catch (\RuntimeException $e) {
+            OA::debug("{$e->getMessage()}, falling back to regular DELETE-based pruning", PEAR_LOG_WARNING);
+        }
+
+        return $this->pruneDSAZAOldDataWithDelete($tblAssoc, $qDate);
     }
 
     /**
      * A method to prune the data_summary_ad_zone_assoc table
      * Prune all entries where the ad_id is for a banner in a High Priority Campaign where:
-    * The campaign does not have any booked lifetime target values AND the caMpaign has an end date AND the end date has been passed AND the campaign is not active.
+     * The campaign does not have any booked lifetime target values AND the campaign has an end date AND the end date has been passed AND the campaign is not active.
      *
      * @return integer : number of records deleted
      */
@@ -104,23 +132,22 @@ class OA_Maintenance_Pruning extends MAX_Dal_Common
             . '      )'
             . '      AND'
             . '      (c.expire_time < ' . $this->oDbh->quote(OA::getNowUTC('Y-m-d H:i:s')) . ')'
-            . ')'
-        ;
+            . ')';
 
         if ($this->oDbh->dbsyntax == 'pgsql') {
             $query = 'DELETE FROM ' . $tblAssoc
-                    . ' WHERE ad_id IN ('
-                    . '  SELECT b.bannerid FROM'
-                    . '  ' . $tblBanners . ' AS b'
-                    . '  JOIN ' . $tblCampaigns . ' AS c ON b.campaignid = c.campaignid'
-                    . $queryEnd
-                    . ')';
+                . ' WHERE ad_id IN ('
+                . '  SELECT b.bannerid FROM'
+                . '  ' . $tblBanners . ' AS b'
+                . '  JOIN ' . $tblCampaigns . ' AS c ON b.campaignid = c.campaignid'
+                . $queryEnd
+                . ')';
         } else {
             $query = 'DELETE FROM ' . $tblAssoc
-                    . ' USING ' . $tblAssoc
-                    . ' JOIN ' . $tblBanners . ' AS b ON ' . $tblAssoc . '.ad_id = b.bannerid'
-                    . ' JOIN ' . $tblCampaigns . ' AS c USE INDEX () ON b.campaignid = c.campaignid'
-                    . $queryEnd;
+                . ' USING ' . $tblAssoc
+                . ' JOIN ' . $tblBanners . ' AS b ON ' . $tblAssoc . '.ad_id = b.bannerid'
+                . ' JOIN ' . $tblCampaigns . ' AS c USE INDEX () ON b.campaignid = c.campaignid'
+                . $queryEnd;
         }
         return $this->oDbh->exec($query);
     }
@@ -131,6 +158,7 @@ class OA_Maintenance_Pruning extends MAX_Dal_Common
      * The campaign has a booked number of lifetime target impressions and/or clicks and/or conversions AND the campaign is not active AND at least one of the booked lifetime target values has been reached.
      *
      * @param integer : the max number of records to delete
+     *
      * @return integer : number of records deleted
      */
     public function _pruneDataSummaryAdZoneAssocInactiveTargetReached($numberToDelete = 100)
@@ -192,5 +220,44 @@ class OA_Maintenance_Pruning extends MAX_Dal_Common
         } else {
             OA::debug('Table ' . $table . ' overhead (number of allocated but unused bytes) = unkown');
         }
+    }
+
+    /**
+     * Prune DSAZA with a regular delete statement.
+     *
+     * @return int|PEAR_Error Deleted rows if successful
+     */
+    private function pruneDSAZAOldDataWithDelete(string $tblAssoc, string $qDate)
+    {
+        return $this->oDbh->exec("DELETE FROM {$tblAssoc} WHERE interval_start < {$qDate}");
+    }
+
+    /**
+     * Prune DSAZA using a temporary table and truncate.
+     *
+     * @return int|PEAR_Error Remaining rows if successful
+     */
+    private function pruneDSAZAOldDataWithTempTable(string $tblAssoc, string $qDate)
+    {
+        $res = $this->oDbh->exec("CREATE TEMPORARY TABLE {$this->prefix}_prune_dsaza AS SELECT * FROM {$tblAssoc} WHERE interval_start >= {$qDate}");
+        if (PEAR::isError($res)) {
+            throw new \RuntimeException('Failed to create temporary table: ' . $res->getMessage());
+        }
+
+        $res = $this->oDbh->exec("TRUNCATE {$tblAssoc}");
+        if (PEAR::isError($res)) {
+            throw new \RuntimeException('Failed to truncate DSAZA: ' . $res->getMessage());
+        }
+
+        $records = $this->oDbh->exec("INSERT INTO {$tblAssoc} SELECT * FROM {$this->prefix}_prune_dsaza");
+        if (PEAR::isError($records)) {
+            OA::debug('Failed to insert records to data_summary_ad_zone_assoc after truncating the table', PEAR_LOG_WARNING);
+            $records = 0;
+        }
+
+        // If the following fails, the table will be dropped at the end of the connection anyway
+        $this->oDbh->exec("DROP TABLE {$this->prefix}_prune_dsaza");
+
+        return $records;
     }
 }

--- a/lib/OA/tests/integration/Cache.cor.test.php
+++ b/lib/OA/tests/integration/Cache.cor.test.php
@@ -131,7 +131,7 @@ class Test_OA_Cache extends UnitTestCase
 
     public function testLifeTime()
     {
-        $oCache = new OA_Cache('test', 'oxpTestCache', 1);
+        $oCache = new OA_Cache('test', 'oxpTestCache', 10);
         $oCache->setFileNameProtection(false);
         $oCache->clear();
 


### PR DESCRIPTION
Historically pruning of the `data_summary_ad_zone_assoc` table has been aggressive only with records having zone_id 0. It is possible that all data was used before changes were made to optimize the "OX Hosted" platform.

From what I can see MPE won't ever use any data that's older than two weeks, so I suppose we can happily prune all those records and massively reduce the size of the table.