### PR TITLE
Fix DO::delete() not returning affected rows

### DIFF
--- a/lib/RV/Bridge/Flysystem/SqlStoredBannerAdapter.php
+++ b/lib/RV/Bridge/Flysystem/SqlStoredBannerAdapter.php
@@ -94,7 +94,7 @@ class SqlStoredBannerAdapter implements AdapterInterface, CanOverwriteFiles
         $doImages = \OA_Dal::staticGetDO('images', $path);
 
         if ($doImages) {
-            return $doImages->delete();
+            return (bool) $doImages->delete();
         }
 
         return false;

--- a/lib/max/Dal/DataObjects/DB_DataObjectCommon.php
+++ b/lib/max/Dal/DataObjects/DB_DataObjectCommon.php
@@ -537,7 +537,7 @@ class DB_DataObjectCommon extends DB_DataObject
         }
         $primaryKey = $keys[0];
         $this->$primaryKey = $primaryId;
-        return $this->delete($useWhere, $cascadeDelete);
+        return (bool) $this->delete($useWhere, $cascadeDelete);
     }
 
     /**
@@ -624,7 +624,7 @@ class DB_DataObjectCommon extends DB_DataObject
      *                                With this parameter it's possible to turn off default behavior
      *                                @see DB_DataObjectCommon:onDeleteCascade
      * @param boolean $parentid The audit ID of the parent object causing the cascade.
-     * @return mixed True on success, false on failure, 0 on no data affected
+     * @return int|false Affected rows on success, false on failure
      * @access protected
      */
     public function delete($useWhere = false, $cascadeDelete = true, $parentid = null)
@@ -663,13 +663,12 @@ class DB_DataObjectCommon extends DB_DataObject
             }
         }
         $result = parent::delete($useWhere);
-        if ($result) {
-            if (!isset($id)) {
-                $doAffected->fetch();
-                $doAffected->audit(3, null, $parentid);
-            }
-            return true;
+
+        if ($result && !isset($id)) {
+            $doAffected->fetch();
+            $doAffected->audit(3, null, $parentid);
         }
+
         return $result;
     }
 

--- a/lib/max/Dal/DataObjects/Images.php
+++ b/lib/max/Dal/DataObjects/Images.php
@@ -86,14 +86,14 @@ class DataObjects_Images extends DB_DataObjectCommon
      *                                With this parameter it's possible to turn off default behavior
      *                                @see DB_DataObjectCommon:onDeleteCascade
      * @param boolean $parentid The audit ID of the parent object causing the cascade.
-     * @return boolean
+     * @return int|false
      * @access protected
      */
     public function delete($useWhere = false, $cascadeDelete = true, $parentid = null)
     {
         // Contents cause problems in pgsql when retrieving current values for auditing
         $this->contents = null;
-        parent::delete($useWhere, $cascadeDelete, $parentid);
+        return parent::delete($useWhere, $cascadeDelete, $parentid);
     }
 
     /**

--- a/lib/max/Dal/DataObjects/Zones.php
+++ b/lib/max/Dal/DataObjects/Zones.php
@@ -98,7 +98,7 @@ class DataObjects_Zones extends DB_DataObjectCommon
      *
      * @param boolean $useWhere
      * @param boolean $cascadeDelete
-     * @return boolean
+     * @return int|false
      * @see DB_DataObjectCommon::delete()
      */
     public function delete($useWhere = false, $cascadeDelete = true, $parentid = null)


### PR DESCRIPTION
While working on DSAZA pruning I've noticed that some parts of the code were expecting `DO::delete()` to return the affected rows. 

I'm not 100% sure this is worth fixing. I'll think a bit about it.