### PR TITLE
Fix: uninitialized variable in XmlRpcUtils causes PHP error

### DIFF
--- a/www/api/v2/common/XmlRpcUtils.php
+++ b/www/api/v2/common/XmlRpcUtils.php
@@ -234,6 +234,7 @@ class XmlRpcUtils
     public static function getArrayOfEntityResponse($aInfoObjects)
     {
         $cRecords = 0;
+        $xmlValue = [];
 
         foreach ($aInfoObjects as $oInfoObject) {
             $xmlValue[$cRecords] = self::getEntityWithNotNullFields($oInfoObject);


### PR DESCRIPTION
When an empty array result is passed to XmlRpcUtils::getArrayOfEntityResponse() the uninitialized variable $xmlValue causes a PHP exception further down the line when `sizeof` is called on it, which expects an array|countable but got a null value.