### PR TITLE
Fix: Plugin installation mixed content error at the end of install 

### DIFF
--- a/www/admin/assets/js/ox.install.js
+++ b/www/admin/assets/js/ox.install.js
@@ -458,6 +458,14 @@
             function init()
             {
                 try {
+					 // Ensure all job URLs use HTTPS if the current page is HTTPS
+					if (window.location.protocol === 'https:') {
+						for (var i = 0; i < settings.jobs.length; i++) {
+							if (settings.jobs[i].url.startsWith('http://')) {
+								settings.jobs[i].url = settings.jobs[i].url.replace('http://', 'https://');
+							}
+						}
+					}
                     build();
 
                     $(document).ajaxJobs({


### PR DESCRIPTION
Fixes issue in revive server latest installation wizard if ran over https  where plugin installation was failing with Error (0) . It makes sure that Ajax calls also over https. Thus solving problem of plugin install failing on modern browser while using SSL. 