### PR TITLE
Allow plugin upgrades when ZIP filename doesn't match package name

### DIFF
--- a/lib/OX/Plugin/PluginManager.php
+++ b/lib/OX/Plugin/PluginManager.php
@@ -566,7 +566,7 @@ class OX_PluginManager extends OX_Plugin_ComponentGroupManager
 
     public function _matchPackageFilename($name, $file)
     {
-        if (!preg_match('/^' . preg_quote($name, '/') . '(?:\W.*)?\.zip$/D', $file)) {
+        if (!preg_match('/^' . preg_quote($name, '/') . '(?:[\W_].*)?\.zip$/D', $file)) {
             $this->_logError('Filename mismatch: name / file ' . $name . ' / ' . $file);
             return false;
         }

--- a/lib/OX/Plugin/PluginManager.php
+++ b/lib/OX/Plugin/PluginManager.php
@@ -566,7 +566,7 @@ class OX_PluginManager extends OX_Plugin_ComponentGroupManager
 
     public function _matchPackageFilename($name, $file)
     {
-        if (!str_starts_with($file, $name)) {
+        if (!preg_match('/^' . preg_quote($name, '/') . '(?:\W.*)?\.zip$/D', $file)) {
             $this->_logError('Filename mismatch: name / file ' . $name . ' / ' . $file);
             return false;
         }

--- a/lib/OX/Plugin/tests/unit/PluginManager.plg.test.php
+++ b/lib/OX/Plugin/tests/unit/PluginManager.plg.test.php
@@ -44,6 +44,22 @@ class Test_OX_PluginManager extends UnitTestCase
         $this->assertEqual($aResult['name'], 'testPlugin');
         $this->assertEqual($aResult['ext'], 'zip');
         $this->assertEqual($aResult['version'], '0.0.1-beta-rc2');
+
+        // Browser-renamed duplicate downloads should be accepted
+        $file = 'testPlugin(1).zip';
+        $aResult = $oManager->_matchPackageFilename($name, $file);
+        $this->assertEqual($aResult['name'], 'testPlugin(1)');
+        $this->assertEqual($aResult['ext'], 'zip');
+
+        // Hyphenated suffixes should be accepted
+        $file = 'testPlugin-v2.zip';
+        $aResult = $oManager->_matchPackageFilename($name, $file);
+        $this->assertEqual($aResult['name'], 'testPlugin-v2');
+        $this->assertEqual($aResult['ext'], 'zip');
+
+        // Name followed by word characters should still be rejected
+        $file = 'testPluginEvil.zip';
+        $this->assertFalse($oManager->_matchPackageFilename($name, $file));
     }
 
     public function test_getPathToPackages()


### PR DESCRIPTION
When upgrading an installed plugin via the Plugins page, the upload is rejected if the ZIP filename doesn't exactly start with the package name. This means files like `myPlugin(1).zip` (browser-renamed duplicate download) or `myPlugin_1.0.3.zip` (version-suffixed) will fail with a confusing error.

The package identity is already verified later in the upgrade flow by reading the `<name>` element from the XML manifest inside the ZIP and comparing it against the installed package. The early filename check in `_matchPackageFilename()` is redundant.

This change makes `_matchPackageFilename()` log a message and proceed when the filename doesn't match, instead of rejecting the upload. The downstream XML-based verification still catches genuinely wrong packages.

Fixes #1667